### PR TITLE
Fix post-merge release recording

### DIFF
--- a/docs/changelogs/skill-open-sourcer.md
+++ b/docs/changelogs/skill-open-sourcer.md
@@ -5,6 +5,7 @@
 - Bind every release plan to the live `origin/main` SHA and fail verification when the remote changes before publication.
 - Require the original checkout path when a temporary clean clone publishes; mark that checkout `needs-sync` and install a pre-commit guard against stale-base commits.
 - Replace direct `main` pushes with short-lived branches and PR merges, and verify that merged remote history contains the planned source before recording publication.
+- Keep post-merge recording valid after GitHub switches the integration checkout to merged `main` by verifying frozen commit objects and candidate refs instead of requiring the old checkout HEAD.
 
 ## 2.3.0 — 2026-07-27
 

--- a/skills/skill-open-sourcer/scripts/release_portfolio.py
+++ b/skills/skill-open-sourcer/scripts/release_portfolio.py
@@ -323,6 +323,37 @@ def verify_plan(plan: dict[str, Any], *, check_remote: bool = True) -> None:
             raise ReleaseError(f"plan.stale: candidate commit changed for {release['skill']}")
 
 
+def verify_frozen_source(plan: dict[str, Any]) -> None:
+    """Verify immutable plan objects after a PR merge changes the checked-out HEAD."""
+    repo = Path(plan["repository"]).resolve()
+    ensure_checkout_ready(repo)
+    base = git(
+        repo,
+        "rev-parse",
+        "--verify",
+        f"{plan['base_commit']}^{{commit}}",
+        check=False,
+    ).stdout.strip()
+    if base != plan["base_commit"]:
+        raise ReleaseError("plan.stale: frozen source commit is unavailable")
+    base_tree = git(repo, "rev-parse", f"{base}^{{tree}}").stdout.strip()
+    for release in plan["releases"]:
+        candidate = git(
+            repo,
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            release["candidate_ref"],
+            check=False,
+        ).stdout.strip()
+        if candidate != release["candidate_commit"]:
+            raise ReleaseError(f"plan.stale: candidate ref changed for {release['skill']}")
+        parent = git(repo, "rev-parse", f"{candidate}^1").stdout.strip()
+        candidate_tree = git(repo, "rev-parse", f"{candidate}^{{tree}}").stdout.strip()
+        if parent != base or candidate_tree != base_tree:
+            raise ReleaseError(f"plan.stale: candidate commit changed for {release['skill']}")
+
+
 def verify_remote_release(plan: dict[str, Any], expected_remote_sha: str) -> str:
     repo = Path(plan["repository"]).resolve()
     actual = remote_head(repo)
@@ -462,7 +493,7 @@ def main() -> int:
             if args.step == "canonical-pushed":
                 if not args.remote_sha:
                     raise ReleaseError("release.remote_sha_required: canonical-pushed needs --remote-sha")
-                verify_plan(plan, check_remote=False)
+                verify_frozen_source(plan)
                 actual_remote = verify_remote_release(plan, args.remote_sha)
                 source_checkout = Path(plan["source_checkout"]).resolve()
                 repository = Path(plan["repository"]).resolve()

--- a/tests/test_release_plan.py
+++ b/tests/test_release_plan.py
@@ -281,6 +281,41 @@ class ReleasePlanTests(unittest.TestCase):
             self.assertEqual(second.returncode, 0, second.stderr)
             self.assertEqual(json.loads(first.stdout), json.loads(second.stdout))
 
+    def test_post_merge_recording_accepts_a_new_head_containing_planned_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            repo.mkdir()
+            self.make_repo(repo)
+            plan_path = Path(tmp) / "plan.json"
+            self.assertEqual(self.plan(repo, plan_path).returncode, 0)
+
+            (repo / "MERGED.md").write_text("merged main\n", encoding="utf-8")
+            self.git(repo, "add", "MERGED.md")
+            self.git(repo, "commit", "-m", "merge result")
+            self.git(repo, "push", "origin", "main")
+            merged_sha = self.git(repo, "rev-parse", "HEAD")
+            command = [
+                sys.executable,
+                str(SCRIPT),
+                "record-step",
+                "--plan",
+                str(plan_path),
+                "--skill",
+                "demo",
+                "--step",
+                "canonical-pushed",
+                "--remote-sha",
+                merged_sha,
+            ]
+            result = subprocess.run(
+                command,
+                text=True,
+                capture_output=True,
+                check=False,
+                env=self.command_env(XDG_STATE_HOME=str(Path(tmp) / "state")),
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_cleanup_deletes_only_the_planned_candidate_ref(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp) / "repo"


### PR DESCRIPTION
## Summary

- verify frozen release commit objects after a PR merge changes the checked-out HEAD
- keep candidate-ref integrity checks and require remote main to contain the planned source
- add a regression test for post-merge recording

## Verification

- release-plan suite: 8 passed
- Skill Open Sourcer suite: 28 passed
- strict Portfolio audit: clear