### PR TITLE
Ignore generated artifacts in isolated install manifests

### DIFF
--- a/docs/changelogs/skill-open-sourcer.md
+++ b/docs/changelogs/skill-open-sourcer.md
@@ -1,5 +1,9 @@
 # skill-open-sourcer Changelog
 
+## 2.4.1 — 2026-07-27
+
+- Exclude generated `dist`, `coverage`, and `reports` directories from isolated-install payload manifests, matching the canonical release manifest and preventing local test artifacts from causing false remote mismatches.
+
 ## 2.4.0 — 2026-07-27
 
 - Bind every release plan to the live `origin/main` SHA and fail verification when the remote changes before publication.

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -206,12 +206,12 @@
     {
       "name": "skill-open-sourcer",
       "lifecycle": "active",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "path": "skills/skill-open-sourcer",
       "documentation": "docs/skills/skill-open-sourcer/README.md",
       "documentation_zh": "docs/skills/skill-open-sourcer/README.zh-CN.md",
       "changelog": "docs/changelogs/skill-open-sourcer.md",
-      "canonical_tag": "skill-open-sourcer/v2.4.0",
+      "canonical_tag": "skill-open-sourcer/v2.4.1",
       "validation": {
         "commands": [
           "python3 -m unittest discover -s skills/skill-open-sourcer/tests -v"

--- a/skills/skill-open-sourcer/scripts/verify_isolated_install.py
+++ b/skills/skill-open-sourcer/scripts/verify_isolated_install.py
@@ -13,7 +13,15 @@ from pathlib import Path
 from typing import Any
 
 
-EXCLUDED_PARTS = {".git", ".agents", "node_modules", "__pycache__"}
+EXCLUDED_PARTS = {
+    ".git",
+    ".agents",
+    "node_modules",
+    "__pycache__",
+    "coverage",
+    "dist",
+    "reports",
+}
 
 
 def digest(path: Path) -> str:

--- a/skills/skill-open-sourcer/tests/test_verify_isolated_install.py
+++ b/skills/skill-open-sourcer/tests/test_verify_isolated_install.py
@@ -98,6 +98,18 @@ class IsolatedInstallVerifierTests(unittest.TestCase):
         self.assertEqual(payload["phase"], "compare")
         self.assertEqual(payload["file_count"], 3)
 
+    def test_generated_directories_are_excluded_from_the_payload_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = self.make_repo(root)
+            generated = repo / "skills" / "demo-skill" / "dist" / "qa"
+            generated.mkdir(parents=True)
+            (generated / "report.md").write_text("generated\n", encoding="utf-8")
+            result = self.run_verifier(repo, self.make_cli(root, "pass"))
+        self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["file_count"], 3)
+
     def test_install_failure_cannot_be_masked_by_later_checks(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

- exclude generated dist, coverage, and reports directories from isolated-install payload manifests
- align isolated-install comparison with the canonical release manifest
- add regression coverage and publish skill-open-sourcer v2.4.1

## Verification

- isolated-install verifier suite: 5 passed
- remote Leadbook install comparison: passed, 52 files
- Portfolio contract: 7 passed
- strict Portfolio audit: clear