### PR TITLE
Add lightweight TeamPlan orchestration to model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npx skills add zjp1997720/zhijian-skills \
 | --- | --- | --- | --- |
 | Codex control | [`codex-doctor`](docs/skills/codex-doctor/README.md) | Diagnose context, configuration, and workspace drift without changing files | [Docs](docs/skills/codex-doctor/README.md) |
 | Codex control | [`codex-handoff`](docs/skills/codex-handoff/README.md) | Continue an oversized or slow Codex task in a fresh task with compact context | [Docs](docs/skills/codex-handoff/README.md) |
-| Codex control | [`codex-model-routing-team`](docs/skills/codex-model-routing-team/README.md) | Route bounded background tasks to explicit models and reasoning levels | [Docs](docs/skills/codex-model-routing-team/README.md) |
+| Codex control | [`codex-model-routing-team`](docs/skills/codex-model-routing-team/README.md) | Compile parallel work into TeamPlans and route Workers to explicit models | [Docs](docs/skills/codex-model-routing-team/README.md) |
 | Codex control | [`codex-skill-admin`](docs/skills/codex-skill-admin/README.md) | Audit, disable, restore, and verify local Codex Skills | [Docs](docs/skills/codex-skill-admin/README.md) |
 | Codex experience | [`codex-theme-studio`](docs/skills/codex-theme-studio/README.md) | Design, apply, verify, and restore reversible Codex Desktop themes | [Docs](docs/skills/codex-theme-studio/README.md) |
 | Knowledge systems | [`enterprise-clone-builder`](docs/skills/enterprise-clone-builder/README.md) | Build a structured enterprise digital-twin repository from evidence | [Docs](docs/skills/enterprise-clone-builder/README.md) |
@@ -63,7 +63,7 @@ npx skills add zjp1997720/zhijian-skills \
 - **Complete installation units.** Supporting scripts, references, themes, and assets travel with each Skill.
 - **Independent versions, one repository.** Every Skill owns its version, Changelog, canonical Tag, and tests while sharing this publishing source.
 
-`codex-model-routing-team` can be invoked explicitly. Its documentation also includes an optional `AGENTS.md` authorization block for automatic activation on complex parallel work.
+`codex-model-routing-team` can be invoked explicitly. Its documentation also includes an optional `AGENTS.md` authorization block for automatic activation when parallel execution has a clear net benefit.
 
 ## Repository model
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,7 +43,7 @@ npx skills add zjp1997720/zhijian-skills \
 | --- | --- | --- | --- |
 | Codex 管理 | [`codex-doctor`](docs/skills/codex-doctor/README.zh-CN.md) | 只读诊断上下文、配置和工作区漂移 | [文档](docs/skills/codex-doctor/README.zh-CN.md) |
 | Codex 管理 | [`codex-handoff`](docs/skills/codex-handoff/README.zh-CN.md) | 把历史过大、响应变慢的 Codex task 换到一个紧凑的新 task 继续 | [文档](docs/skills/codex-handoff/README.zh-CN.md) |
-| Codex 管理 | [`codex-model-routing-team`](docs/skills/codex-model-routing-team/README.zh-CN.md) | 把后台任务分配给明确的模型和推理强度 | [文档](docs/skills/codex-model-routing-team/README.zh-CN.md) |
+| Codex 管理 | [`codex-model-routing-team`](docs/skills/codex-model-routing-team/README.zh-CN.md) | 把并行工作编译成 TeamPlan，并将 Worker 路由到明确模型 | [文档](docs/skills/codex-model-routing-team/README.zh-CN.md) |
 | Codex 管理 | [`codex-skill-admin`](docs/skills/codex-skill-admin/README.zh-CN.md) | 审计、关闭、恢复并验证本地 Codex Skill | [文档](docs/skills/codex-skill-admin/README.zh-CN.md) |
 | Codex 体验 | [`codex-theme-studio`](docs/skills/codex-theme-studio/README.zh-CN.md) | 设计、注入、验证并恢复可逆的 Codex Desktop 主题 | [文档](docs/skills/codex-theme-studio/README.zh-CN.md) |
 | 知识系统 | [`enterprise-clone-builder`](docs/skills/enterprise-clone-builder/README.zh-CN.md) | 从企业证据构建结构化数字分身仓库 | [文档](docs/skills/enterprise-clone-builder/README.zh-CN.md) |
@@ -63,7 +63,7 @@ npx skills add zjp1997720/zhijian-skills \
 - **安装包保持完整。** 每个 Skill 依赖的脚本、参考资料、主题和资源都会一起安装。
 - **版本独立，仓库统一。** 每个 Skill 保留独立版本、Changelog、统一仓库 Tag 和测试。
 
-`codex-model-routing-team` 可以手动点名，也可以通过文档提供的 `AGENTS.md` 授权块，在复杂并行任务中自动触发。
+`codex-model-routing-team` 可以手动点名，也可以通过文档提供的 `AGENTS.md` 授权块，在并行执行具有明确净收益时自动触发。
 
 ## 仓库模型
 

--- a/docs/changelogs/codex-model-routing-team.md
+++ b/docs/changelogs/codex-model-routing-team.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add a lightweight TeamPlan compiler and dependency-free validator before every two-or-more-Worker dispatch, covering dependencies, same-wave ownership conflicts, budgets, integration order, and lead-only final verification.
+- Compile CE Plans, Codex Plans, and upstream Skill decompositions without rewriting them; keep two-to-three-unit micro plans in context and persist only durable four-plus-Worker or resumable runs.
+- Bind Worker ledger entries to `team_plan_revision` and `unit_id`, reject mid-wave structural revisions and plan-external Workers, and warn when valid units remain undispatched.
+- Replace vague complexity activation with a net-benefit gate that preserves the quality floor and compares expected time or model-cost savings against coordination cost.
 - Make `speed` a versioned RoutePlan dimension with backward-compatible legacy Standard behavior.
 - Default automatic routing to Luna XHigh App Thread, raise difficult or high-risk tasks to Luna Max, and keep native V2 only for explicit requests or predeclared fallback.
 - Treat Luna as App-only while the official native V2 live schema omits it; require Sol High or stronger on every Surface and reject Sol Medium/Low even when explicitly requested.

--- a/docs/skills/codex-model-routing-team/README.md
+++ b/docs/skills/codex-model-routing-team/README.md
@@ -8,7 +8,7 @@
 
 <p align="center"><a href="./README.zh-CN.md">简体中文</a> · <a href="https://github.com/zjp1997720/zhijian-skills/tree/main/skills/codex-model-routing-team">Canonical source</a></p>
 
-Use it for complex parallel work when one lead Agent should plan and integrate while bounded Workers run on explicitly chosen models, reasoning levels, and speeds.
+Use it when parallel execution has a clear net benefit: the lead compiles a lightweight TeamPlan, bounded Workers own independent deliverables, and explicit RoutePlans choose their models, reasoning levels, and speeds.
 
 ## Install
 
@@ -39,7 +39,7 @@ npx skills ls -g -a codex
 find ~/.agents/skills/codex-model-routing-team -maxdepth 2 -type f | sort
 ```
 
-The file list must include `SKILL.md`, `references/model-registry.json`, `references/audit-schema.json`, `references/native-audit-schema.json`, `references/surface-selection-policy.md`, `references/native-subagent-lifecycle.md`, `references/routing-policy.md`, `references/provider-policy.md`, `references/recovery-policy.md`, `references/task-packet.md`, `references/thread-lifecycle.md`, `references/thread-supervision-protocol.md`, `scripts/route_policy.py`, `scripts/model_preflight.py`, `scripts/validate_route_plan.py`, and `scripts/validate_team_ledger.py`. If only `SKILL.md` appears, remove that incomplete installation and install the current release again.
+The file list must include `SKILL.md`, `references/team-plan.md`, `references/model-registry.json`, `references/audit-schema.json`, `references/native-audit-schema.json`, `references/surface-selection-policy.md`, `references/native-subagent-lifecycle.md`, `references/routing-policy.md`, `references/provider-policy.md`, `references/recovery-policy.md`, `references/task-packet.md`, `references/thread-lifecycle.md`, `references/thread-supervision-protocol.md`, `scripts/route_policy.py`, `scripts/model_preflight.py`, `scripts/validate_team_plan.py`, `scripts/validate_route_plan.py`, and `scripts/validate_team_ledger.py`. If only `SKILL.md` appears, remove that incomplete installation and install the current release again.
 
 ## Activate it
 
@@ -54,7 +54,8 @@ To let Codex activate the Skill automatically for suitable complex work, add the
 ```markdown
 ## Codex background model-routing authorization
 
-- The user authorizes Codex to use `$codex-model-routing-team` automatically for complex, parallelizable tasks. Default to independent Luna XHigh App threads and raise high-risk or difficult work to Luna Max. Before dispatch, briefly state the Worker count, surface, model, reasoning level, speed, and responsibility. No additional confirmation is required.
+- The user authorizes Codex to use `$codex-model-routing-team` automatically when work can be safely split into at least two independently verifiable deliverables and the expected time or model-cost savings exceed creation, supervision, and integration cost without lowering the quality floor. Before dispatch, briefly state the Worker count, surface, exact model, reasoning level, speed, and responsibility. No additional confirmation is required.
+- Before creating two or more Workers, the lead must compile a lightweight TeamPlan. Existing CE Plans, Codex Plans, and upstream Skill plans are compiled rather than rewritten. TeamPlan does not create a separate Planner, enter a heavyweight planning flow, or persist files by default.
 - The lead agent keeps its current model and owns planning, file ownership, integration, verification, and final delivery.
 - Use App threads by default. Native subagents are explicit-request or predeclared-fallback only because the current official V2 live schema does not expose Luna.
 - Run at most 6 Workers concurrently and make at most 8 Worker attempts for one root task; failures, non-materialized calls, and fallbacks count. Workers must not create more Workers or subagents.
@@ -68,13 +69,14 @@ This is user-configured Codex instruction, not a hidden OpenAI system prompt. Ex
 
 Current official Codex native V2 spawn schemas can expose per-worker model and reasoning controls, but the live schema does not expose Luna. Support remains runtime- and surface-specific, and a proxy catalog cannot be treated as evidence of official native support.
 
-This Skill therefore defaults to App threads so Luna remains available. Ordinary complex work starts at Luna XHigh and difficult or high-risk work rises to Luna Max. Native Sol remains available only for explicit requests or predeclared fallback, under the same Provider gates, attempt budget, and lead-agent verification.
+This Skill therefore defaults to App threads so Luna remains available. Ordinary work starts at Luna XHigh and difficult or high-risk work rises to Luna Max. Before dispatch, TeamPlan fixes units, dependencies, ownership, outputs, acceptance, and integration order; RoutePlan separately controls model routing. Native Sol remains available only for explicit requests or predeclared fallback.
 
 Ordinary automatic groups use the governed App-thread path. `native-light` is retained only for explicit native requests or predeclared fallback; it validates RoutePlans and ledgers through stdin and avoids creating `agent_team/`. Both profiles keep the same safety gates.
 
 ## What it does
 
-- Routes only complex, genuinely parallel work such as multi-source research, multi-section content, large Skills or decks, and independent engineering workstreams.
+- Uses a net-benefit gate: at least two independently verifiable deliverables, with expected savings greater than coordination cost; otherwise the lead executes directly.
+- Requires and validates a lightweight TeamPlan before dispatching two or more Workers, while compiling existing plans without rewriting them.
 - Defaults to Luna XHigh App threads and raises difficult or high-risk work to Luna Max. Native Luna is rejected; Sol is High/XHigh/Max only and remains Standard. App Luna may use Fast only when the live create schema accepts `service_tier=priority`; Grok 4.5 stays conditional on runtime/provider preflight.
 - Keeps `gpt-5.6-terra` opt-in and first-candidate-only. An unknown-model response fails that exact native route and never silently inherits the parent model.
 - Retains explicit Gemini 3.6 Flash route templates while blocking the current third-party Antigravity login path; an official API/Vertex path needs a separate registry entry.
@@ -90,24 +92,25 @@ Ordinary automatic groups use the governed App-thread path. `native-light` is re
 
 ## How it works
 
-1. The lead freezes a task profile, Provider allowlist, execution surface, and ordered candidate chain.
-2. It validates the registry and Provider policy, then confirms every native `model/reasoning_effort/speed` against the live spawn schema; Fast must accept `service_tier=priority`.
-3. Automatic work uses governed Luna App threads. `native-light` is used only for an explicit native request or a predeclared fallback, with Sol High or stronger.
-4. Native V1 uses `fork_context=false`; V2 uses `fork_turns="none"`. App threads keep unique task ids and recover queued worktrees through official reads.
-5. Requested, platform-accepted, and observed runtime identities remain separate for both model and speed. Missing runtime identity stays `unknown`.
-6. Failures advance only through the predeclared chain, including cross-surface fallbacks. A single-candidate failure returns to the lead agent.
-7. Adopted native Workers are closed; adopted App threads pass the completion and archival gates.
+1. The lead passes the net-benefit gate, compiles two or three TeamPlan units, and validates their graph and ownership before dispatch.
+2. Each unit receives one Task Packet and one RoutePlan with a Provider allowlist, surface, and ordered candidate chain.
+3. Registry and Provider policy are validated; native `model/reasoning_effort/speed` combinations also need live schema evidence, and Fast must accept `service_tier=priority`.
+4. Automatic work uses governed Luna App threads. `native-light` is explicit-request or predeclared-fallback only, with Sol High or stronger.
+5. Native V1 uses `fork_context=false`; V2 uses `fork_turns="none"`. App threads keep unique task ids and recover queued worktrees through official reads.
+6. Requested, platform-accepted, and observed identities remain separate; failures advance only through the predeclared chain.
+7. The lead verifies and integrates in TeamPlan order, closes adopted native Workers, and applies App completion and archival gates.
 
 The lightweight path can validate in-memory JSON without leaving coordination files:
 
 ```bash
+printf '%s' "$TEAM_PLAN_JSON" | python3 scripts/validate_team_plan.py -
 printf '%s' "$ROUTE_PLAN_JSON" | python3 scripts/validate_route_plan.py -
 printf '%s' "$TEAM_LEDGER_JSON" | python3 scripts/validate_team_ledger.py -
 ```
 
 `max_worker_threads` equals the candidate-chain length. A single candidate with lead-agent takeover uses `1`; a declared fallback chain uses `2`.
 
-When an upstream Skill already owns decomposition, this Skill accepts its stages and task budget. It controls model routing, task lifecycle, and safety caps without rewriting the upstream workflow. Any task with a workspace output path is project-bound; only chat-only work may be projectless.
+When an upstream Skill already owns decomposition, this Skill compiles those units into TeamPlan while preserving stages, artifacts, and quality gates. It does not invent a second domain plan. Any task with a workspace output path is project-bound; only chat-only work may be projectless.
 
 The default Deep Research budget is `2-4 researchers + 1 verifier + 1 reviewer + 2 retry slots`, within the cumulative eight-task cap.
 
@@ -155,7 +158,7 @@ The agent workflow lives in [SKILL.md](../../../skills/codex-model-routing-team/
 
 ## Validation
 
-The workflow covers App-first Luna XHigh/Max routing, static rejection of Native Luna and Sol Medium/Low, Sol/Terra Standard boundaries, rejection of App Fast without a live speed schema, opt-in Terra fallback, conditional Grok 4.5, and provider blocking for explicit Gemini requests. Validation includes surface-aware preflight, RoutePlan and speed-audit checks, native close gates, queued-worktree recovery, mixed ledgers, and isolated `npx skills` installation.
+The workflow covers net-benefit selection; TeamPlan dependency layers, same-wave write conflicts, budget, revisions, and unplanned Worker detection; App-first Luna XHigh/Max routing; Native Luna and Sol Medium/Low rejection; speed audit; queued-worktree recovery; mixed ledgers; and isolated `npx skills` installation.
 
 ## License
 

--- a/docs/skills/codex-model-routing-team/README.zh-CN.md
+++ b/docs/skills/codex-model-routing-team/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 <p align="center"><a href="./README.md">English</a> · <a href="https://github.com/zjp1997720/zhijian-skills/tree/main/skills/codex-model-routing-team">统一源码</a></p>
 
-适合复杂并行任务：主 Agent 负责规划、文件所有权和集成，Worker 按明确 Surface、模型、推理强度与速度执行。
+适合存在明确净并行收益的任务：主 Agent 先把工作编译成轻量 TeamPlan，再让 Worker 按独立交付物、明确所有权和精确模型路由执行，最后统一集成与验收。
 
 ## 安装
 
@@ -39,7 +39,7 @@ npx skills ls -g -a codex
 find ~/.agents/skills/codex-model-routing-team -maxdepth 2 -type f | sort
 ```
 
-文件列表至少应包含 `SKILL.md`、`references/model-registry.json`、`references/audit-schema.json`、`references/native-audit-schema.json`、`references/surface-selection-policy.md`、`references/native-subagent-lifecycle.md`、`references/routing-policy.md`、`references/provider-policy.md`、`references/recovery-policy.md`、`references/task-packet.md`、`references/thread-lifecycle.md`、`references/thread-supervision-protocol.md`、`scripts/route_policy.py`、`scripts/model_preflight.py`、`scripts/validate_route_plan.py` 和 `scripts/validate_team_ledger.py`。如果只有 `SKILL.md`，说明装到的是旧版残缺包，删除后重新安装当前版本。
+文件列表至少应包含 `SKILL.md`、`references/team-plan.md`、`references/model-registry.json`、`references/audit-schema.json`、`references/native-audit-schema.json`、`references/surface-selection-policy.md`、`references/native-subagent-lifecycle.md`、`references/routing-policy.md`、`references/provider-policy.md`、`references/recovery-policy.md`、`references/task-packet.md`、`references/thread-lifecycle.md`、`references/thread-supervision-protocol.md`、`scripts/route_policy.py`、`scripts/model_preflight.py`、`scripts/validate_team_plan.py`、`scripts/validate_route_plan.py` 和 `scripts/validate_team_ledger.py`。如果只有 `SKILL.md`，说明装到的是旧版残缺包，删除后重新安装当前版本。
 
 ## 启用方式
 
@@ -54,7 +54,8 @@ find ~/.agents/skills/codex-model-routing-team -maxdepth 2 -type f | sort
 ```markdown
 ## Codex 后台模型路由授权
 
-- 用户长期授权 Codex 在复杂、可并行任务中自动使用 `$codex-model-routing-team`；默认创建 Luna XHigh App 独立 Thread，高难或高风险任务升 Luna Max；派遣前用一条简短通知说明数量、Surface、模型、强度、速度和职责，无需再次确认。
+- 用户长期授权：当任务可安全拆成两个以上拥有独立交付物的 Worker 单元，且预计在不降低质量下限的前提下，时间或模型成本净收益高于创建、协调和集成成本时，自动使用 `$codex-model-routing-team`；派遣前简报数量、Surface、精确模型、强度、速度和职责，无需再次确认。
+- 准备创建两个以上 Worker 时，主 Agent 必须先生成轻量 TeamPlan；已有 CE Plan、Codex Plan 或上游 Skill 计划时只编译、不重写。TeamPlan 默认不创建独立 Planner、不进入重型规划流程、不写持久文件。
 - 主 Agent 保持当前模型，负责规划、文件所有权、集成、验证和最终交付。
 - 默认使用 App Thread。当前官方 V2 live schema 不开放 Luna，原生 Subagent 只用于用户明确点名或预声明 fallback。
 - 跨 Surface 同时运行最多 6 个 Worker；单个根任务累计最多 8 次 Worker attempt，失败、未实体化和 fallback 都计数。Worker 不得继续创建任何后台任务或子 Agent。
@@ -68,13 +69,14 @@ find ~/.agents/skills/codex-model-routing-team -maxdepth 2 -type f | sort
 
 当前 Codex 官方原生 V2 的 spawn schema 可以暴露每个 Worker 的模型和推理强度，但 live schema 不开放 Luna。可用性仍取决于具体 runtime 和 Surface；代理 catalog 也不能作为官方原生能力证据。
 
-因此这个 Skill 默认使用 App Thread，确保能调用 Luna：普通复杂任务从 XHigh 起步，高难或高风险任务升 Max。原生 Sol 仅用于显式请求或预声明 fallback；两条路径共享 Provider 门、fallback 计划、次数预算和主 Agent 验收。
+因此这个 Skill 默认使用 App Thread，确保能调用 Luna：普通任务从 XHigh 起步，高难或高风险任务升 Max。派遣前，轻量 TeamPlan 先固定单元、依赖、所有权、交付物、验收和集成顺序；原生 Sol 仅用于显式请求或预声明 fallback。TeamPlan 管编排，RoutePlan 管模型路由，两条 Surface 共享 Provider 门、fallback 计划、次数预算和主 Agent 验收。
 
 普通自动路由默认走完整 `governed` App Thread 路径。`native-light` 只保留给显式原生请求或预声明 fallback：RoutePlan 和 ledger 可通过 stdin 校验并留在上下文，不创建 `agent_team/`。两档共享同一套安全门。
 
 ## 主要能力
 
-- 只路由真正复杂且可并行的任务，例如多来源调研、多章节内容、复杂 Skill 或 PPT、跨模块开发和独立验证。
+- 用净收益门判断是否派遣：至少两个单元拥有独立交付物与完成条件，且节省高于协调成本；否则由主 Agent 直接完成。
+- 两个以上 Worker 必须先编译并校验轻量 TeamPlan，明确依赖、写入所有权、交付物、验收和集成顺序；已有计划只编译、不重写。
 - 默认使用 Luna XHigh App Thread，高难或高风险任务升 Luna Max。Native Luna 静态拒绝；Sol 仅允许 High/XHigh/Max 且始终 Standard。App Luna 只有在 live create schema 接受 `service_tier=priority` 时才使用 Fast；Grok 4.5 在 runtime/provider 预检后承担复杂执行和异构审查。
 - `gpt-5.6-terra` 为 opt-in，只能作为用户明确点名的首项候选；unknown model 只判定该精确原生组合失败，禁止静默继承父模型。
 - Gemini 3.6 Flash 保留显式路由模板，但当前 Antigravity 第三方登录路径受官方条款阻断；正式 API/Vertex 路径需要新的 registry entry。
@@ -90,24 +92,25 @@ find ~/.agents/skills/codex-model-routing-team -maxdepth 2 -type f | sort
 
 ## 工作方式
 
-1. 主 Agent 固定任务画像、Provider allowlist、执行 Surface 和有序候选链。
-2. 校验 registry 与 Provider 门；每个原生 `model/reasoning_effort/speed` 精确组合还要通过 live spawn schema，Fast 必须接受 `service_tier=priority`。
-3. 自动路由使用 governed Luna App Thread；只有显式原生请求或预声明 fallback 才使用 `native-light`，且 Sol 最低 High。
-4. 原生 V1 使用 `fork_context=false`，V2 使用 `fork_turns="none"`；App Thread 使用唯一 task id 和官方读取恢复排队 worktree。
-5. 模型与速度都分开记录 requested、platform accepted 与 observed runtime；平台未回显时 observed 保持 `unknown`。
-6. 失败只沿预声明链前进，包括跨 Surface fallback；单候选失败后由主 Agent 接管。
-7. 已采纳的原生 Worker 必须关闭；App Thread 必须通过完成与归档门。
+1. 主 Agent 通过净收益门；两个以上 Worker 时把任务编译为 2–3 个 TeamPlan unit，并先运行结构校验。
+2. 为每个 unit 固定任务画像、Provider allowlist、执行 Surface 和有序候选链，生成对应 Task Packet 与 RoutePlan。
+3. 校验 registry 与 Provider 门；每个原生 `model/reasoning_effort/speed` 精确组合还要通过 live spawn schema，Fast 必须接受 `service_tier=priority`。
+4. 自动路由使用 governed Luna App Thread；只有显式原生请求或预声明 fallback 才使用 `native-light`，且 Sol 最低 High。
+5. 原生 V1 使用 `fork_context=false`，V2 使用 `fork_turns="none"`；App Thread 使用唯一 task id 和官方读取恢复排队 worktree。
+6. 模型与速度都分开记录 requested、platform accepted 与 observed runtime；失败只沿预声明链前进。
+7. 主 Agent 按 TeamPlan 集成顺序验收；已采纳原生 Worker 必须关闭，App Thread 必须通过完成与归档门。
 
 轻量路径可以直接从 stdin 校验，不留下临时协调文件：
 
 ```bash
+printf '%s' "$TEAM_PLAN_JSON" | python3 scripts/validate_team_plan.py -
 printf '%s' "$ROUTE_PLAN_JSON" | python3 scripts/validate_route_plan.py -
 printf '%s' "$TEAM_LEDGER_JSON" | python3 scripts/validate_team_ledger.py -
 ```
 
 `max_worker_threads` 必须等于候选链长度：单候选且失败后由主 Agent 接管时写 `1`；声明 fallback 候选时写 `2`。
 
-上游 Skill 已经完成任务拆分时，本 Skill 接受其阶段顺序和任务预算，只负责模型路由、任务生命周期与安全上限。声明工作区输出路径的任务始终绑定项目；只有纯聊天交付才能使用 projectless。
+上游 Skill 已经完成任务拆分时，本 Skill把现有单元编译为 TeamPlan，保留其阶段顺序、产物和质量门，不再猜一套计划。声明工作区输出路径的任务始终绑定项目；只有纯聊天交付才能使用 projectless。
 
 Deep Research 默认预算为 `2-4 个 researcher + 1 个 verifier + 1 个 reviewer + 2 个重试位`，总数不超过 8 个。
 
@@ -155,7 +158,7 @@ Agent 的完整工作流见 [SKILL.md](../../../skills/codex-model-routing-team/
 
 ## 验证情况
 
-工作流已经覆盖 App-first Luna XHigh/Max、Native Luna 与 Sol Medium/Low 的静态拒绝、Sol/Terra Standard 边界、App Fast 缺少速度 schema 的拒绝、Terra opt-in fallback、条件 Grok 4.5 和 Gemini Provider 阻断；包含 Surface 预检、RoutePlan 校验、速度审计、原生关闭门、pending worktree 恢复、混合 ledger 校验和隔离 `npx skills` 安装。
+工作流已经覆盖净收益判断、TeamPlan 依赖层、同波写冲突、预算、修订和计划外 Worker 校验，以及 App-first Luna XHigh/Max、Native Luna 与 Sol Medium/Low 的静态拒绝、速度审计、pending worktree 恢复、混合 ledger 和隔离 `npx skills` 安装。
 
 ## 许可证
 

--- a/docs/superpowers/specs/2026-08-01-codex-model-routing-team-teamplan-design.md
+++ b/docs/superpowers/specs/2026-08-01-codex-model-routing-team-teamplan-design.md
@@ -1,0 +1,332 @@
+# Codex Model Routing Team：轻量 TeamPlan 编译层
+
+## 决策摘要
+
+在现有 `codex-model-routing-team` 内增加轻量 TeamPlan 编译层，不新建独立 Planner Skill。主 Agent 准备创建两个及以上 Worker 时，必须先把根任务或已有上游计划编译为可验证的 Worker 执行图，再为每个单元生成现有 RoutePlan 和 Task Packet。
+
+TeamPlan 负责「谁做什么、何时执行、如何交付与集成」；RoutePlan 继续负责 `surface / model / thinking / speed`。已有 CE Plan、Codex Plan 模式结果或领域 Skill 计划时只编译、不重写业务目标、阶段、路径和质量门。
+
+自动触发不再依赖任务是否笼统地“复杂”。只要任务存在明确净并行收益，且可以在不降低质量下限的前提下更快或更省，就应自动使用本 Skill。TeamPlan 必须保持轻量：默认由主 Agent 一次编译 2–3 个 Worker 单元，不创建 Planner Worker、不调用重型计划流程、不写持久计划文件。
+
+## 问题
+
+当前 Skill 已经定义模型路由、Provider 与数据边界、Task Packet、Thread 生命周期、失败回退、并发限制、单写者和主 Agent 验收，但从“值得并行”直接跳到“为每个子任务生成 RoutePlan”。它声明主 Agent 负责规划和分工，却没有规定子任务如何从根任务产生。
+
+Task Packet 解决的是已经决定派遣之后如何给 Worker 完整上下文；RoutePlan 解决的是该 Worker 在哪个 Surface、使用什么模型和推理强度；两者都不负责：
+
+- 把总目标拆成几个有边界的执行单元；
+- 判断哪些单元可以并行、哪些必须串行；
+- 分配文件或语义所有权；
+- 约定 Worker 之间的交付接口；
+- 安排集成顺序、验证职责和重试额度；
+- 在并行收益低于协调成本时主动拒绝派遣。
+
+有上游业务 Skill 时，上游计划天然补足这层；普通复杂任务直接触发模型路由时，主 Agent 只能临时编写分工，质量、粒度和上下文成本都不稳定。
+
+## 目标
+
+- 对所有两个及以上 Worker 的自动或显式调度建立统一、轻量、可验证的分工契约。
+- 将领域规划、团队编排和模型路由分成三个稳定层级。
+- 让主 Agent 主动评估净并行收益，做到应派尽派，同时避免为了 MultiAgent 而 MultiAgent。
+- 保留主 Agent 对目标、关键判断、文件所有权、集成、最终验证和交付的责任。
+- 复用现有 RoutePlan 2.1、Task Packet、双 Surface 生命周期、ledger 和恢复协议。
+- 对 2–3 Worker 的普通任务保持低上下文和低延迟，不引入第二套业务账本。
+
+## 非目标
+
+- 不新建独立 Team Planner Skill。
+- 不替代 CE Plan、Codex Plan 模式、Deep Research 或其他领域规划流程。
+- 不让 Worker 自己拆分任务或继续创建 Agent、Thread 和后台任务。
+- 不改变 Luna、Sol、Terra、Grok、Gemini、Fast、Provider 或 fallback 策略。
+- 不让 TeamPlan 记录 Thread 运行状态或替代现有 ledger。
+- 不为单 Worker、简单问答、状态查询、单文件小改或强顺序任务强制创建 TeamPlan。
+- 不自动修改 Compound Engineering 插件缓存、Codex Plan 模式或 `light-plan-and-work`。
+
+## 三层计划架构
+
+| 层级 | 回答的问题 | 权威来源 |
+| --- | --- | --- |
+| Domain / Implementation Plan | 做什么、采用什么业务或技术方案 | CE Plan、Codex Plan、上游 Skill 或已确认的用户目标 |
+| TeamPlan | 哪些 Worker 做什么、依赖和所有权是什么、怎样集成与验收 | `codex-model-routing-team` |
+| RoutePlan | 每个单元在哪个 Surface、使用什么模型、推理强度和速度 | 现有 RoutePlan 2.1 与模型注册表 |
+
+TeamPlan 不得填补尚未确认的产品需求或领域方案。如果目标、边界或验收仍不明确，应回到相应的 discovery、brainstorming、CE Plan 或领域 Skill；不能为了凑出 Worker 图而猜测。
+
+## 自动触发收益门
+
+主 Agent 用一次有界判断回答三个问题：
+
+1. 能否拆出至少两个边界清楚、各自拥有独立交付物的 Worker 单元？
+2. 能否为每个单元定义完成标准，同时由主 Agent 保留集成和最终验证？
+3. 预计并行节省的关键路径时间或模型成本，是否高于 Thread 创建、上下文准备、监督和结果集成成本？
+
+三个条件同时满足时自动启用本 Skill，无需额外询问用户，也不再判断任务是否“足够复杂”。不满足时输出一句简短的 `lead_only` 原因并由主 Agent直接完成；负向路径不构造完整 TeamPlan。
+
+质量下限通过硬门而不是主观承诺保证：
+
+- 没有明确完成标准的单元不得派遣；
+- 关键业务判断和最终责任不得下放；
+- Worker 输出本身不能作为完成证据；
+- 主 Agent 必须检查真实文件、来源或运行结果并完成全局验证；
+- 模型仍遵守 Luna XHigh 起步、高难或高风险升 Max、Sol High 起步等现有规则。
+
+现有自动禁用边界继续保留：简单问答、状态查询、单文件小改、强顺序任务以及发布、发送、付款、删除、账户和生产操作不自动派遣。Worker 只能为不可逆外部动作准备材料。
+
+## TeamPlan 契约
+
+TeamPlan 使用 `schema_version: "1.0"`。`units` 只记录 Worker 单元；主 Agent 的责任由顶层集成与最终验证字段明确保留。默认最小形状为：
+
+```yaml
+schema_version: "1.0"
+revision: 1
+supersedes_revision: null
+planning_source: ad_hoc | codex_plan | ce_plan | upstream_skill
+source_refs: []
+root_goal: "最终要完成的结果"
+units:
+  - unit_id: U1
+    role: researcher | implementer | verifier | reviewer | custom
+    goal: "该 Worker 要完成什么"
+    output: "可检查的交付物或路径"
+    depends_on: []
+    ownership:
+      write: []
+      forbidden: []
+    done_when: "可观察的完成条件"
+  - unit_id: U2
+    role: verifier
+    goal: "独立验证另一个有边界的子目标"
+    output: "验证结论或声明路径"
+    depends_on: []
+    ownership:
+      write: []
+      forbidden: []
+    done_when: "验证证据完整且可由主 Agent 复核"
+reserved_slots: 2
+integration_order: [U1, U2]
+final_verification: "主 Agent 的全局验收"
+revision_reason: initial
+```
+
+每个 Worker 只有七个核心字段：`unit_id / role / goal / output / depends_on / ownership / done_when`。`supersedes_revision` 在初始版本为 `null`，后续 revision 必须指向直接上一版本。数据等级、Provider、工具、模型、推理强度和速度继续进入 Task Packet 与 RoutePlan，不复制进 TeamPlan。
+
+`source_refs` 在上游模式下记录计划路径、稳定单元 ID 或 Codex Plan 的会话内来源标识。TeamPlan 引用上游事实，不复制完整需求正文。`ownership.write` 为空表示只读或只返回聊天结果；写入任务必须使用仓库相对路径或上游定义的可移植输出标识。
+
+## 轻量与耐久模式
+
+### 微型 TeamPlan（默认）
+
+- 一般包含 2–3 个 Worker 单元；
+- 由主 Agent 一次有界扫描生成；
+- 不创建 Planner Worker；
+- 不为拆分任务做全仓研究；
+- 不自动调用 CE Plan；
+- 不写持久 TeamPlan 文件；
+- 通过 stdin 交给 validator；
+- 派遣前只向用户展示 Worker 数、精确路由和职责简报，不倾倒完整 JSON。
+
+### 耐久 TeamPlan
+
+出现任一信号时复用现有 durable mode：四个以上 Worker、多阶段、预计长时间运行、需要中断恢复、上游已有耐久账本或用户明确要求持久记录。TeamPlan 作为现有 run envelope 的计划部分保存，不能创建第二套状态事实源。
+
+如果一次有界编译后仍无法写清交付物、依赖或验收，停止继续猜测。主 Agent直接执行，或在原任务本身确实需要重型规划时进入 CE Plan／领域工作流。
+
+## 上游计划适配
+
+### CE Plan
+
+- 保留稳定 U-ID，并写入 `source_refs`；
+- `Dependencies` 映射为 `depends_on`；
+- `Files` 用于建立 `ownership`，但主 Agent 仍需判断读写性质；
+- `Goal`、`Verification` 和相关 Test Scenarios 编译为 `goal` 与 `done_when`；
+- 不调用 `ce-work`，避免它与本 Skill 同时成为 Orchestrator；
+- 不重新研究或重写 Product Contract、KTD、Definition of Done 和业务范围。
+
+### Codex Plan 模式
+
+Plan 模式中的步骤只作为输入。退出只读 Plan 模式后，主 Agent 才将其编译成 TeamPlan，并补足交付物、依赖、所有权和验收。原计划不能直接当作 Worker Task Packet。
+
+### 领域 Skill
+
+上游 Skill 继续拥有任务目标、Scale、业务单元、阶段顺序、产出路径和质量门。TeamPlan 只增加 Worker 分配、依赖检查、所有权、预算和集成顺序；遇到冲突时，上游业务流程优先，现有路由安全上限仍保持强制。
+
+## 调度与数据流
+
+```mermaid
+flowchart TD
+    A[净并行收益判断] --> B{有上游计划}
+    B -- 有 --> C[编译已有计划]
+    B -- 无 --> D[主 Agent 生成微型 TeamPlan]
+    C --> E[validate_team_plan]
+    D --> E
+    E -->|失败| F[修正一次或主 Agent 接管]
+    E -->|通过| G[从依赖图计算就绪单元]
+    G --> H[每单元生成 RoutePlan 与 Task Packet]
+    H --> I[每波最多派遣三个 Worker]
+    I --> J[收集并验证真实结果]
+    J --> K{新证据是否改变任务结构}
+    K -- 否 --> L[主 Agent 按顺序集成]
+    K -- 是 --> M[当前波收口后生成新 revision]
+    M --> E
+    L --> N{仍有未完成单元}
+    N -- 有 --> G
+    N -- 无 --> O[主 Agent 全局验证与交付]
+```
+
+依赖图是调度的唯一事实源。Validator 从 DAG 计算就绪层，再按“每波新增最多 3 个”切分；TeamPlan 不重复手写 wave，避免依赖与波次矛盾。跨 Surface 同时运行最多 6 个、根任务累计最多 8 次 Worker attempt 的现有限制保持不变。
+
+每个 Worker 单元必须形成唯一链路：
+
+```text
+TeamPlan Unit
+  ├─ Task Packet
+  ├─ RoutePlan
+  └─ Worker Ledger Record
+```
+
+App 与 native 两套 Worker 审计记录增加 `unit_id` 和 `team_plan_revision`。Run envelope 使用 `{team_plans, active_team_plan_revision, workers}`：普通任务的 `team_plans` 只有 revision 1；发生结构性重规划时按顺序保留旧 revision，并由 `active_team_plan_revision` 指向当前版本。微型模式在主 Agent 上下文中保留该 envelope，并通过 stdin 交给最终 ledger validator；耐久模式把同一对象写入已有账本。TeamPlan 是计划事实，不记录 Thread 控制状态。
+
+## 所有权与并行安全
+
+Validator 拒绝同一就绪层中明显重叠的写入范围，包括相同路径和父子路径。未声明写入边界、使用过宽目录、通配规则无法安全解析或语义所有权不明确时，主 Agent 必须串行化或重新拆分，而不能把 validator 的沉默当作并行安全证明。
+
+文件不重叠也不等于语义独立。共享 API、schema、migration、lockfile、生成物、注册表、单例服务、数据库、浏览器会话或速率限制仍由主 Agent 在收益门和 Task Packet 中判断。并行速度是可选收益，正确性优先。
+
+## 失败与重规划
+
+三类失败必须分开处理：
+
+1. **路由失败**：精确 Surface／模型／强度／速度不可用时，只沿该单元预声明的 RoutePlan fallback 前进，不修改 TeamPlan。
+2. **Worker 执行失败**：输出不完整或单元验证失败时，仍属于同一 unit；先进行一次 follow-up，必要时使用第二次 Worker attempt，不重新拆计划。
+3. **任务结构失效**：只有新证据改变依赖、所有权、交付物、范围或验收时，才允许生成 TeamPlan 新 revision。
+
+重规划只能在当前派遣波全部收口后发生。新 revision 必须记录失效证据、尚未派出单元的差异和剩余预算；已完成或正在运行的单元不得被静默改写。上一 revision 仍有活动 Worker 时，validator／ledger gate 拒绝派遣新 revision。
+
+Unit ID 在一个根任务内保持稳定：语义未变的单元沿用原 ID；拆分时原概念保留原 ID，新概念使用下一个未使用 ID；被删除的 ID 留空且不得复用；目标发生实质替换时使用新 ID。Worker ledger 通过 `team_plan_revision + unit_id` 解析该次派遣的确切语义。
+
+如果一次 revision 仍无法形成明确单元，停止重规划并由主 Agent接管或进入任务原本需要的重型计划流程。
+
+## Validator 设计
+
+新增无第三方依赖的 `scripts/validate_team_plan.py`，与现有 validator 一样接受单个 revision 的 JSON 文件路径或 `-` stdin，并输出机器可读 JSON。它检查：
+
+- schema version、根目标、revision 和来源字段；
+- 至少两个且不超过并发上限的 Worker 单元；
+- unit ID 唯一，依赖存在、无自依赖和无环；
+- 每个单元具有 role、goal、output、ownership 和 done_when；
+- 同一就绪层不存在明显写入路径重叠；
+- `planned workers + reserved_slots <= 8`；
+- integration order 只引用真实单元、覆盖全部单元并尊重依赖顺序；
+- final verification 非空且明确由主 Agent负责；
+- 上游模式存在 source refs；
+- revision 与 revision reason 合法；revision 大于 1 时声明被替代的上一版本。
+
+Validator 输出计算后的 dispatch waves，但不把 waves 写回 TeamPlan。它不判断技术方案正确性、隐含语义冲突、模型选择或 Worker 是否真实完成。
+
+现有 `validate_team_ledger.py` 在 root envelope 含 `team_plans` 时另外检查：
+
+- revisions 单调递增且 `active_team_plan_revision` 指向已存在版本；
+- 每个 Worker 记录引用该 revision 中真实的 `unit_id`；
+- 没有计划外 Worker；
+- fallback 仍关联原 unit；
+- 新 revision 派遣前旧 revision 没有活动 Worker；
+- 被采纳结果仍满足现有 materialization、identity、output、close／archive 门。
+
+未派遣的计划单元作为 run summary 警告和主 Agent 交付检查项，不一律判为 ledger 错误：它可能因 revision 替换、静态路由门或主 Agent 接管而没有 Worker attempt。最终交付必须说明其处置，不能静默遗漏。
+
+## 全局 AGENTS.md 同步
+
+用户级系统提示词只保留跨项目的授权和硬门，不复制 TeamPlan schema。自动触发语义调整为：当任务可以安全拆成两个以上拥有独立交付物的 Worker 单元，且预计在不降低质量下限的前提下，时间或模型成本净收益高于创建、协调和集成成本时，自动使用 `$codex-model-routing-team`。
+
+另增加一条：准备创建两个以上 Worker 时，主 Agent 必须先生成轻量 TeamPlan；已有 CE Plan、Codex Plan 或上游 Skill 计划时只编译、不重写。TeamPlan 默认不创建独立 Planner、不进入重型规划流程、不写持久文件。
+
+模型、并发、Fast、Provider、禁用动作和派遣前简报规则保持不变。全局文件是用户环境配置，不进入 Portfolio commit；在 Skill 实现完成后单独同步并进行新任务验证。
+
+## 文件范围
+
+计划新增：
+
+- `skills/codex-model-routing-team/references/team-plan.md`
+- `skills/codex-model-routing-team/scripts/validate_team_plan.py`
+- `skills/codex-model-routing-team/evals/team-planning.json`
+
+计划修改：
+
+- `skills/codex-model-routing-team/SKILL.md`
+- `skills/codex-model-routing-team/references/task-packet.md`
+- `skills/codex-model-routing-team/references/upstream-skill-adapter.md`
+- `skills/codex-model-routing-team/references/durable-mode.md`
+- `skills/codex-model-routing-team/references/validation-cases.md`
+- 两套 audit schema 与 `scripts/validate_team_ledger.py`
+- `agents/openai.yaml` 与 `agents/interface.yaml`
+- `tests/skills/test_codex_model_routing_team.py` 与 expected contract
+- 中英文 README、changelog 和 Registry 版本／验证元数据
+- 用户级 `~/.codex/AGENTS.md`（不进入仓库提交）
+
+不修改模型注册表、路由矩阵、Fast、Provider、CE 插件缓存、Codex Plan 模式或 `light-plan-and-work`。
+
+不新增独立 JSON Schema 引擎。字段契约由 `team-plan.md` 描述，机器判断统一由 dependency-free validator 完成，避免两套规则漂移。
+
+## 测试与验证
+
+### Validator 正常路径
+
+- 两个独立 Worker 形成一个就绪层；
+- 三个独立 Worker 保持单波；
+- 四个独立 Worker 自动切为 `3 + 1`；
+- 依赖单元进入后续就绪层；
+- CE Plan U-ID 和上游 source refs 正确保留；
+- 微型 TeamPlan 通过 stdin 验证且不创建状态目录。
+
+### Validator 拒绝路径
+
+- 缺少 output、ownership 或 done_when；
+- unit ID 重复、依赖不存在、自依赖或成环；
+- 同波写入相同文件或父子目录；
+- Worker 与 reserved slots 超出 8 次预算；
+- integration order 遗漏或引用未知单元；
+- integration order 违反依赖顺序；
+- final verification 缺失或下放给 Worker；
+- 上游模式缺少 source refs；
+- 新 revision 在旧波次仍活动时派遣；
+- ledger 出现计划外 Worker、错误 revision 或 unit 映射；
+- 未派遣单元未在最终 run summary 中说明处置。
+
+### 行为评测
+
+- 任务不大但净并行收益明确时自动派遣；
+- 看似复杂但强顺序或集成成本高时由主 Agent完成；
+- 三个独立来源自动拆成三个 Luna Worker；
+- 两个 Worker 修改同一文件时串行化或重新分配所有权；
+- 已有 CE Plan 时编译 U-ID，不重做计划；
+- Codex Plan 模式结果在退出只读模式后再编译；
+- 路由失败只使用 RoutePlan fallback；
+- 新依赖只在当前波收口后触发 revision。
+
+### 轻量性回归
+
+- 2–3 Worker 不创建 Planner Thread、不调用 CE Plan、不写持久 TeamPlan 文件；
+- `lead_only` 路径不构造完整 TeamPlan；
+- Skill 初始正文继续满足现有 3000 字符门，详细规则按需加载；
+- 现有 RoutePlan、模型、Fast、Provider、生命周期、恢复和 ledger 测试保持通过；
+- 运行 Skill 定向测试、Portfolio contract／audit、隔离安装和完整回归。
+
+## 验收标准
+
+- 任意两个以上 Worker 的派遣都有通过验证的 TeamPlan；
+- 每个 Worker 可追溯到唯一 TeamPlan unit、Task Packet、RoutePlan 和 ledger 记录；
+- 主 Agent 保留集成和最终验证，计划无法把责任下放；
+- 普通 2–3 Worker 任务不创建 Planner、重型计划或持久文件；
+- 上游计划仍是业务 SSOT，TeamPlan 不复制或改写其业务含义；
+- 同波明显写入冲突、依赖环、计划外 Worker、超预算和非法 revision 被机器拒绝；
+- 不改变现有模型路由、Fast、Provider 与失败恢复语义；
+- 全局自动授权从“复杂任务”收敛为“净并行收益为正”，同时保留现有禁用和安全边界。
+
+## 风险与控制
+
+- **计划开销反噬收益**：默认 2–3 单元、一次有界编译、stdin 校验，不创建 Planner 或持久文件。
+- **机器校验制造虚假安全感**：Validator 只证明结构不变量；语义冲突、方案正确性和真实运行结果仍由主 Agent验证。
+- **上游与 TeamPlan 双重 SSOT**：上游计划拥有业务事实，TeamPlan 仅引用并增加调度字段；运行状态只进入现有 ledger。
+- **运行中频繁重规划**：只在结构性证据出现且当前波收口后生成 revision；路由或输出质量失败不触发重规划。
+- **全局提示词膨胀**：全局只增加收益门和 TeamPlan 强制门，schema、适配和 validator 细节留在 Skill references。
+- **初始 Skill 上下文回涨**：SKILL.md 只保留触发、轻量门和引用，继续受 3000 字符回归测试约束。

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -51,17 +51,17 @@
     {
       "name": "codex-model-routing-team",
       "lifecycle": "active",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "path": "skills/codex-model-routing-team",
       "documentation": "docs/skills/codex-model-routing-team/README.md",
       "documentation_zh": "docs/skills/codex-model-routing-team/README.zh-CN.md",
       "changelog": "docs/changelogs/codex-model-routing-team.md",
-      "canonical_tag": "codex-model-routing-team/v2.1.0",
+      "canonical_tag": "codex-model-routing-team/v2.2.0",
       "validation": {
         "commands": [
           "python3 -m unittest tests.skills.test_codex_model_routing_team -v"
         ],
-        "live_smoke": "Run one Luna XHigh App thread canary, confirm native V2 rejects or omits Luna, and confirm Sol Medium is statically rejected while Sol High remains eligible; record requested, accepted, and observed model and speed identity separately"
+        "live_smoke": "Validate a two-unit TeamPlan before dispatch, run one Luna XHigh App thread canary, confirm native V2 rejects or omits Luna, and confirm Sol Medium is statically rejected while Sol High remains eligible; record TeamPlan unit/revision and requested, accepted, and observed model and speed identity separately"
       },
       "capabilities": {
         "network": "required",

--- a/skills/codex-model-routing-team/SKILL.md
+++ b/skills/codex-model-routing-team/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: codex-model-routing-team
-description: 为复杂、可并行任务默认创建 Luna XHigh/Max Codex App Thread，并在 live schema 支持时使用原生 fallback，由主 Agent 负责数据边界、分工、集成和验收。用于多个独立工作流、来源/章节/模块、独立验证，或用户明确要求模型路由、后台 Worker、Agents Team、Grok/Gemini Worker。简单问答、状态查询、单文件小改、强顺序任务和不可逆操作不自动触发。
+description: 为存在明确净并行收益的任务编译轻量 TeamPlan，默认创建 Luna XHigh/Max Codex App Thread，并在 live schema 支持时使用原生 fallback。用于两个以上有独立交付物的工作流、来源/章节/模块、独立验证，或用户明确要求模型路由、后台 Worker、Agents Team、Grok/Gemini Worker。简单问答、状态查询、单文件小改、强顺序任务和不可逆操作不自动触发。
 ---
 
 # Codex 模型路由团队
 
-主 Agent 保持当前模型并负责规划、文件所有权、集成和验收。默认路由为 `app_thread/gpt-5.6-luna/xhigh`，高难/高风险升 `max`；`native_subagent` 只用于显式请求或预声明 fallback。
+主 Agent 保持当前模型并负责规划、文件所有权、集成和验收。两个以上 Worker 先编译轻量 TeamPlan；默认路由为 `app_thread/gpt-5.6-luna/xhigh`，高难/高风险升 `max`；`native_subagent` 只用于显式请求或预声明 fallback。
 
 ## 不使用
 
@@ -13,20 +13,21 @@ description: 为复杂、可并行任务默认创建 Luna XHigh/Max Codex App Th
 
 ## 执行模式
 
-- `governed`（默认）：2–3 个 Luna App Thread，XHigh 起步；短任务从 stdin 校验，需要恢复/worktree/审计时按 [耐久模式](references/durable-mode.md) 留状态。
+- `governed`（默认）：主 Agent 一次编译 2–3 unit 微型 TeamPlan，Luna App Thread 从 XHigh 起步；TeamPlan/RoutePlan/ledger 从 stdin 校验，需要恢复/worktree/审计时按 [耐久模式](references/durable-mode.md) 留状态。
 - `native-light`（显式/回退）：App 不可用时须预声明；Luna 不可走原生，Sol 最低 High。
 - 上游 Skill 已定义拆分、阶段和产物时，遵守 [适配协议](references/upstream-skill-adapter.md)，不重做 Scale、阶段门或第二套账本。
 
 ## 执行流程
 
-1. 确认用户显式或 `AGENTS.md` 长期授权，并验证并行收益；不满足则主 Agent 直接完成。
-2. 读取 [模型注册表](references/model-registry.json)、[Provider 策略](references/provider-policy.md) 和 [路由策略](references/routing-policy.md)，固定数据边界与精确 `surface/model/thinking/speed`；Surface 有歧义时读取 [选择策略](references/surface-selection-policy.md)。
-3. 为每个子任务生成 `schema_version: "2.1"` RoutePlan 并运行 `scripts/validate_route_plan.py`。原生组合必须有 live `runtime_evidence`；App Fast 必须有 live `speed_evidence`。
-4. 按 [任务包](references/task-packet.md) 写唯一 `task_id`、权限、验收和“禁止创建后台任务/线程/子 Agent”；派遣前简报 Worker 数、精确路由、职责、fallback 与 reserved slots。
-5. 原生路径遵守 [生命周期](references/native-subagent-lifecycle.md) 与 [审计 schema](references/native-audit-schema.json)；App 路径遵守 [Thread 生命周期](references/thread-lifecycle.md)、[监督协议](references/thread-supervision-protocol.md) 与 [审计 schema](references/audit-schema.json)。
-6. 跨 Surface 并发最多 6、根任务累计 `worker_attempt` 最多 8、每波新增最多 3；每子任务最多 2 次 Worker attempt、原 Worker 最多一次 follow-up；预留后续阶段/恢复额度并保持单写者。
-7. 失败只按 [恢复策略](references/recovery-policy.md) 沿预声明链前进；不得随机选模、循环回退、改变 `thinking/speed`、扩大 Provider，或用换模型掩盖 MCP 故障。
-8. 主 Agent 验证并集成交付，关闭已采纳原生 Worker，仅归档满足收尾门的 App Thread；运行 `scripts/validate_team_ledger.py` 后汇报路由、尝试、fallback、采纳、关闭/归档与风险。
+1. 确认用户显式或 `AGENTS.md` 长期授权；只有至少两个独立交付物、验收质量不下降且节省高于协调成本时派遣，否则简报 `lead_only` 并直接完成。
+2. 两个以上 Worker 按 [TeamPlan 协议](references/team-plan.md) 编译 unit、依赖、所有权、交付物、验收和集成顺序，并运行 `scripts/validate_team_plan.py`；已有上游计划时只编译、不重写。
+3. 读取 [模型注册表](references/model-registry.json)、[Provider 策略](references/provider-policy.md) 和 [路由策略](references/routing-policy.md)，为每个 unit 固定数据边界与精确 `surface/model/thinking/speed`；Surface 有歧义时读取 [选择策略](references/surface-selection-policy.md)。
+4. 每个 unit 生成 `schema_version: "2.1"` RoutePlan 并运行 `scripts/validate_route_plan.py`。原生组合必须有 live `runtime_evidence`；App Fast 必须有 live `speed_evidence`。
+5. 按 [任务包](references/task-packet.md) 写 `unit_id/team_plan_revision`、唯一 `task_id`、权限、验收和禁止下级派遣；派遣前简报 Worker 数、精确路由、职责、fallback 与 reserved slots。
+6. 原生路径遵守 [生命周期](references/native-subagent-lifecycle.md)；App 路径遵守 [Thread 生命周期](references/thread-lifecycle.md) 与 [监督协议](references/thread-supervision-protocol.md)。
+7. 跨 Surface 并发最多 6、根任务累计 8 次 Worker attempt、每波新增最多 3；每 unit 最多 2 次 attempt、原 Worker 最多一次 follow-up，并保持单写者。
+8. 失败只按 [恢复策略](references/recovery-policy.md) 沿预声明链前进；只有依赖、所有权、交付物、范围或验收发生结构变化时，才在当前波收口后修订 TeamPlan。
+9. 主 Agent 验证并集成交付，关闭已采纳原生 Worker，仅归档满足收尾门的 App Thread；运行 `scripts/validate_team_ledger.py` 后汇报 TeamPlan、路由、尝试、fallback、采纳与收尾状态。
 
 ## 硬门
 
@@ -35,6 +36,7 @@ description: 为复杂、可并行任务默认创建 Luna XHigh/Max Codex App Th
 - Fast 是 `service_tier=priority`，不是模型 ID；只有 Luna 可用，Sol、Terra 和其他模型一律 Standard。App Surface 未显式接受速度参数时 Luna 保持 Standard，不得声称 Fast。
 - Terra 仅在用户点名时作为首项；Grok 须通过 runtime/provider 门；Gemini Antigravity 当前 blocked。禁止自动使用旧模型、Ultra 或低于最低 `thinking` 的 fallback。
 - Worker 不得继续派生任务，也不得执行发布、发送、付款、删除、账户或生产变更。主 Agent 不切换自身模型。
+- TeamPlan 默认不创建 Planner、不调用重型计划、不落持久文件；同波写冲突、依赖环、超预算、计划外 Worker 或下放最终验收必须拒绝。
 - `pendingWorktreeId`/未知返回值不可管理；零或多匹配进入 `UNKNOWN`，禁止追问、归档、fallback、重复创建或修改 Codex 数据库。上游阶段门始终优先。
 
 ## 输出契约

--- a/skills/codex-model-routing-team/agents/interface.yaml
+++ b/skills/codex-model-routing-team/agents/interface.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Codex 模型路由团队"
-  short_description: "默认用 Luna XHigh/Max App Thread 路由复杂任务"
-  default_prompt: "使用 $codex-model-routing-team 判断并行收益，固定 Surface、模型、推理、速度、Provider 门和候选链，由主 Agent 集成验收。"
+  short_description: "轻量 TeamPlan 调度 Luna XHigh/Max Worker"
+  default_prompt: "使用 $codex-model-routing-team 判断净收益、编译 TeamPlan，再为各单元固定精确路由，由主 Agent 集成验收。"
 compatibility:
   canonical_format: "agent-skills"
   adapter_targets:
@@ -17,4 +17,4 @@ compatibility:
     remote_inline_execution: "forbid"
     remote_metadata_policy: "deny"
   degradation:
-    openai: "Default to Luna XHigh/Max App threads. Native V2 is explicit/fallback only; Luna is App-only and Sol requires High or stronger. Fast requires service_tier=priority."
+    openai: "Use Luna XHigh/Max App threads. Native V2 is explicit/fallback only; Sol starts at High. Luna Fast requires service_tier=priority."

--- a/skills/codex-model-routing-team/agents/openai.yaml
+++ b/skills/codex-model-routing-team/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Codex 模型路由团队"
-  short_description: "默认用 Luna XHigh/Max App Thread 路由复杂任务"
-  default_prompt: "使用 $codex-model-routing-team 判断并行收益，固定 Surface、模型、推理、速度、Provider 门和候选链，由主 Agent 集成验收。"
+  short_description: "轻量 TeamPlan 调度 Luna XHigh/Max Worker"
+  default_prompt: "使用 $codex-model-routing-team 判断净收益、编译 TeamPlan，再为各单元固定精确路由，由主 Agent 集成验收。"
 policy:
   allow_implicit_invocation: true

--- a/skills/codex-model-routing-team/evals/team-planning-semantic-config.json
+++ b/skills/codex-model-routing-team/evals/team-planning-semantic-config.json
@@ -1,0 +1,71 @@
+{
+  "fallback_positive_concepts": [
+    "parallel_team",
+    "explicit_routing"
+  ],
+  "positive_concepts": {
+    "parallel_team": {
+      "weight": 0.55,
+      "phrases": [
+        "并行任务",
+        "多个独立工作流",
+        "两个以上有独立交付物的工作流",
+        "独立交付物",
+        "并行核验",
+        "并行完成",
+        "并行做",
+        "parallel work",
+        "independent deliverables"
+      ]
+    },
+    "explicit_routing": {
+      "weight": 0.45,
+      "phrases": [
+        "模型路由",
+        "后台 worker",
+        "agents team",
+        "luna worker",
+        "grok worker",
+        "gemini worker",
+        "model routing",
+        "background workers"
+      ]
+    }
+  },
+  "negative_concepts": {
+    "small_or_single": {
+      "weight": 0.65,
+      "exclusive": true,
+      "phrases": [
+        "单文件",
+        "一个错别字",
+        "只让一个 worker",
+        "single file",
+        "one worker"
+      ]
+    },
+    "status_or_explain": {
+      "weight": 0.65,
+      "exclusive": true,
+      "phrases": [
+        "什么状态",
+        "解释一下",
+        "不需要执行任务",
+        "status check",
+        "just explain"
+      ]
+    },
+    "unsafe_or_sequential": {
+      "weight": 0.75,
+      "exclusive": true,
+      "phrases": [
+        "直接发布",
+        "不要创建 worker",
+        "严格按顺序",
+        "协调成本会高于并行收益",
+        "publish directly",
+        "strictly sequential"
+      ]
+    }
+  }
+}

--- a/skills/codex-model-routing-team/evals/team-planning-trigger-cases.json
+++ b/skills/codex-model-routing-team/evals/team-planning-trigger-cases.json
@@ -1,0 +1,49 @@
+{
+  "recommended_threshold": 0.4,
+  "should_trigger": [
+    {
+      "text": "把六个独立来源分给后台 Worker 并行核验，每个来源都有独立交付物，最后统一汇总。",
+      "family": "net_parallel_benefit"
+    },
+    {
+      "text": "使用模型路由把实现、测试和审查分给三个 Worker，文件所有权不能重叠。",
+      "family": "explicit_model_routing"
+    },
+    {
+      "text": "让 Agents Team 并行完成三章内容，主 Agent 负责集成验收。",
+      "family": "explicit_team"
+    },
+    {
+      "text": "用 Luna Worker 并行做四份可独立验收的调研，速度和成本都有净收益。",
+      "family": "luna_workers"
+    }
+  ],
+  "should_not_trigger": [
+    {
+      "text": "把 README 里的一个错别字改掉。",
+      "family": "single_file_small_edit"
+    },
+    {
+      "text": "告诉我这个任务现在是什么状态。",
+      "family": "status_query"
+    },
+    {
+      "text": "直接发布这条推文，不要创建 Worker。",
+      "family": "irreversible_external_action"
+    }
+  ],
+  "near_neighbor": [
+    {
+      "text": "解释一下 Luna 和 Sol 的模型差异，不需要执行任务。",
+      "family": "model_explanation"
+    },
+    {
+      "text": "这个修改必须严格按顺序完成，协调成本会高于并行收益。",
+      "family": "sequential_negative_benefit"
+    },
+    {
+      "text": "只让一个 Worker 检查单个文件。",
+      "family": "single_worker"
+    }
+  ]
+}

--- a/skills/codex-model-routing-team/evals/team-planning.json
+++ b/skills/codex-model-routing-team/evals/team-planning.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "id": "small-net-positive-team",
+      "prompt": "同时核对三个独立来源并汇总，任务不大，但并行更快且每份都有独立验收。",
+      "expected_output": "自动使用 Skill；主 Agent 生成 3-unit 微型 TeamPlan，从 stdin 校验后按单波派遣 Luna XHigh App Worker；不创建 Planner、CE Plan 或持久文件。",
+      "failure_signals": ["任务不够复杂", "创建 Planner", "调用 ce-plan", "没有 TeamPlan"]
+    },
+    {
+      "id": "dependency-and-write-collision",
+      "prompt": "让两个 Worker 并行修改 scripts/router.py，再由第三个 Worker 验证。",
+      "expected_output": "TeamPlan validator 拒绝同波写入冲突；主 Agent 重分所有权或增加依赖，验证单元等待实现单元完成。",
+      "failure_signals": ["直接并行写同一文件", "只靠 worktree 避免语义冲突"]
+    },
+    {
+      "id": "compile-existing-ce-plan",
+      "prompt": "现有 CE Plan 已定义 U1/U2、Dependencies、Files 和 Verification，请用模型路由团队执行。",
+      "expected_output": "保留上游 U-ID、阶段和验收，只编译 TeamPlan 调度字段；不调用 ce-work，不重写领域计划。",
+      "failure_signals": ["重新生成 CE Plan", "修改上游业务目标", "第二套业务账本"]
+    },
+    {
+      "id": "adjacent-lead-only",
+      "prompt": "把 README 里的一个错别字改掉。",
+      "expected_output": "主 Agent 直接完成；不构造 TeamPlan，不创建 Worker。",
+      "failure_signals": ["创建 Thread", "生成完整 TeamPlan"]
+    },
+    {
+      "id": "revision-only-after-wave",
+      "prompt": "第一波 Worker 仍在运行，但新证据改变了后续依赖，请立即派第二版计划。",
+      "expected_output": "先收口当前波；旧 revision 仍活动时拒绝派遣新 revision，之后记录 supersedes_revision 与 revision_reason。",
+      "failure_signals": ["旧 Worker 运行时派新 revision", "把路由失败当成重规划"]
+    }
+  ]
+}

--- a/skills/codex-model-routing-team/references/audit-schema.json
+++ b/skills/codex-model-routing-team/references/audit-schema.json
@@ -56,6 +56,8 @@
       "enum": ["none", "declared-output-only", "declared-workspace", "isolated-worktree"]
     },
     "result_correlation_id": {"type": ["string", "null"]},
+    "unit_id": {"type": "string", "pattern": "^U[1-9][0-9]*$"},
+    "team_plan_revision": {"type": "integer", "minimum": 1},
     "role": {"type": "string", "minLength": 1},
     "model": {"type": "string", "minLength": 1},
     "requested_model": {"type": "string", "minLength": 1},

--- a/skills/codex-model-routing-team/references/durable-mode.md
+++ b/skills/codex-model-routing-team/references/durable-mode.md
@@ -4,7 +4,7 @@
 
 自动路由本身已经默认使用 `app_thread`。本文件决定何时把轻量 App Thread 执行升级为持久状态模式：涉及外部/生产/账户/成本审批；需要跨任务恢复、worktree、独立任务历史或严格 Thread 审计；用户明确要求项目管理或持续执行。
 
-预计超过 30 分钟或有 4 个以上正式交付物只是耐久信号，不单独触发持久状态目录。短时、文件所有权互斥、回到父任务集成的多文件工作仍使用 Luna App Thread，但 RoutePlan/ledger 可从 stdin 校验，不创建 `agent_team/`。原生 Subagent 只用于显式请求或预声明 fallback。
+预计超过 30 分钟、四个以上 Worker 或有 4 个以上正式交付物只是耐久信号，不单独触发持久状态目录。短时、2–3 个 Worker、文件所有权互斥、回到父任务集成的工作仍使用微型 [TeamPlan](team-plan.md) 和 Luna App Thread，TeamPlan/RoutePlan/ledger 可从 stdin 校验，不创建 `agent_team/`。原生 Subagent 只用于显式请求或预声明 fallback。
 
 ## 状态目录
 
@@ -20,7 +20,7 @@ agent_team/
   handoffs/
 ```
 
-`state.json` 至少记录：根任务目标、模式、策略版本、并发/worker attempt 计数、每个 RoutePlan 的有序候选链、Provider allowlist、健康证据，以及遵守 [Thread 审计 schema](audit-schema.json) 的 Worker 记录。每个 Worker 使用唯一 `task_id`；正式 id、pending id、`control_state` 和最新官方观察分开记录。未返回正式 thread id 的创建尝试也必须保留。
+`state.json` 至少记录：根任务目标、模式、策略版本、`team_plans`、`active_team_plan_revision`、并发/worker attempt 计数、每个 RoutePlan 的有序候选链、Provider allowlist、健康证据，以及遵守 [Thread 审计 schema](audit-schema.json) 的 Worker 记录。每个 Worker 使用唯一 `task_id` 并记录 `unit_id/team_plan_revision`；正式 id、pending id、`control_state` 和最新官方观察分开记录。未返回正式 thread id 的创建尝试也必须保留。
 
 `task-board.md` 展示待办、执行中、待集成、完成、阻塞。`packets/` 保存正式任务包，`handoffs/` 保存可恢复的交接摘要。
 
@@ -39,6 +39,8 @@ python3 scripts/validate_team_ledger.py /path/to/state.json
 ```
 
 validator 只检查确定性状态不变量，不把本地 ledger 伪装成实时 Thread 真相。
+
+TeamPlan revision 只能在当前波全部收口后新增。路由失败沿原 RoutePlan fallback，输出质量不足沿原 unit follow-up；只有依赖、所有权、交付物、范围或验收发生结构变化时才修订 TeamPlan。
 
 ## rollback boundary
 

--- a/skills/codex-model-routing-team/references/native-audit-schema.json
+++ b/skills/codex-model-routing-team/references/native-audit-schema.json
@@ -40,6 +40,8 @@
     "agent_status": {"type": ["string", "null"]},
     "last_observed_at": {"type": ["string", "null"], "format": "date-time"},
     "fork_mode": {"const": "fresh"},
+    "unit_id": {"type": "string", "pattern": "^U[1-9][0-9]*$"},
+    "team_plan_revision": {"type": "integer", "minimum": 1},
     "role": {"type": "string", "minLength": 1},
     "model": {"type": "string", "minLength": 1},
     "requested_model": {"type": "string", "minLength": 1},

--- a/skills/codex-model-routing-team/references/task-packet.md
+++ b/skills/codex-model-routing-team/references/task-packet.md
@@ -7,6 +7,8 @@
 你是本任务的独立执行 Worker。禁止创建任何后台任务、线程或子 Agent。
 
 - task_id：
+- unit_id（TeamPlan 模式必填）：
+- team_plan_revision（TeamPlan 模式必填）：
 - surface：`native_subagent | app_thread`
 - task_intent：`mutate | inspect | verify`
 - mutation_authority：`none | declared-output-only | declared-workspace | isolated-worktree`
@@ -53,5 +55,7 @@
 主 Agent 另外记录所选 Surface、`model`、`thinking`、`speed` 与选择理由。任务包中严禁声称 Worker 已加载某个预制 Agent Type。
 
 主 Agent 还要在任务包之外保存 `schema_version: "2.1"` 的 RoutePlan：任务画像、精确候选链、最低 `thinking`、速度、Provider 策略、健康证据和 fallback 条件。Worker 不自行选择或切换模型/速度，也不需要看到其他候选的凭证与配额信息。
+
+准备创建两个及以上 Worker 时，任务包必须来自已通过 `scripts/validate_team_plan.py` 的 [TeamPlan](team-plan.md)。每个 Worker unit 恰好生成一份初始任务包和一份 RoutePlan；fallback attempt 沿用相同 `unit_id/team_plan_revision`，但必须使用新的 `task_id`。
 
 上游 Skill 模式下，任务包必须原样保留上游定义的输出路径、阶段依赖和验收标准。路由层可以收紧安全边界，不能扩大写入范围或跳过质量门。

--- a/skills/codex-model-routing-team/references/team-plan.md
+++ b/skills/codex-model-routing-team/references/team-plan.md
@@ -1,0 +1,103 @@
+# 轻量 TeamPlan 编译协议
+
+当主 Agent 准备创建两个及以上 Worker 时读取本协议。TeamPlan 只负责任务编排；模型、推理强度、速度、Provider 和 fallback 继续由每个单元自己的 RoutePlan 决定。
+
+## 收益门
+
+一次有界判断同时满足以下条件才自动派遣：
+
+1. 至少两个 Worker 单元各有独立交付物；
+2. 每个单元都有可检查的完成条件，主 Agent 保留集成和最终验收；
+3. 预计节省的时间或模型成本高于创建、监督和集成成本。
+
+不满足时简报 `lead_only` 原因并直接执行，不构造 TeamPlan。简单问答、状态查询、单文件小改、强顺序任务和不可逆外部操作仍不自动派遣。
+
+## 最小契约
+
+默认由主 Agent 一次编译 2–3 个 Worker，不创建 Planner、不调用重型计划流程、不写持久文件。通过 stdin 校验：
+
+```json
+{
+  "schema_version": "1.0",
+  "revision": 1,
+  "supersedes_revision": null,
+  "planning_source": "ad_hoc",
+  "source_refs": [],
+  "root_goal": "交付完整且经主 Agent 验证的结果",
+  "units": [
+    {
+      "unit_id": "U1",
+      "role": "researcher",
+      "goal": "完成第一个独立子目标",
+      "output": "可检查的结论或路径",
+      "depends_on": [],
+      "ownership": {"write": [], "forbidden": []},
+      "done_when": "证据完整且可复核"
+    },
+    {
+      "unit_id": "U2",
+      "role": "verifier",
+      "goal": "完成第二个独立子目标",
+      "output": "独立验证结论",
+      "depends_on": [],
+      "ownership": {"write": [], "forbidden": []},
+      "done_when": "验证覆盖关键风险"
+    }
+  ],
+  "reserved_slots": 2,
+  "integration_owner": "lead",
+  "integration_order": ["U1", "U2"],
+  "final_verification": "主 Agent 检查真实产物并完成全局验收",
+  "revision_reason": "initial"
+}
+```
+
+每个 Worker 只保留 `unit_id / role / goal / output / depends_on / ownership / done_when` 七个核心字段。Task Packet 再补数据边界、Provider、上下文、权限和验证命令。
+
+运行：
+
+```bash
+python3 scripts/validate_team_plan.py /path/to/team-plan.json
+printf '%s' "$TEAM_PLAN_JSON" | python3 scripts/validate_team_plan.py -
+```
+
+## 来源适配
+
+- `ad_hoc`：目标已经明确，主 Agent 直接编译。
+- `ce_plan`：保留 U-ID、依赖、文件、测试与验收引用，不调用 `ce-work`，不重写领域方案。
+- `codex_plan`：退出只读 Plan 模式后再编译；会话内计划只作为来源。
+- `upstream_skill`：上游拥有 Scale、阶段、路径和业务质量门；本层只增加 Worker、所有权、预算和集成顺序。
+
+非 `ad_hoc` 来源必须写 `source_refs`。引用上游计划，不复制完整正文，也不创建第二套业务账本。
+
+## 调度与所有权
+
+- 依赖图是唯一调度事实源；validator 计算就绪层并按每波最多 3 个切分。
+- 同一就绪层出现相同或父子写入路径时拒绝，主 Agent 必须增加依赖、串行化或重分所有权。
+- 文件不重叠不等于语义独立；共享 API、schema、migration、lockfile、生成物、服务、数据库、浏览器会话和限流仍由主 Agent 判断。
+- `planned workers + reserved_slots <= 8`；Worker 单元最多 6 个，跨 Surface 并发仍最多 6。
+- `integration_order` 必须覆盖全部单元并尊重依赖；`integration_owner` 固定为 `lead`。
+
+验证通过后，每个 unit 恰好生成一份 Task Packet 和一份 RoutePlan。派遣简报只展示 Worker 数、精确路由和职责，不向用户倾倒 TeamPlan JSON。
+
+## Revision
+
+路由失败只走 RoutePlan fallback；输出质量失败仍属于原 unit。只有新证据改变依赖、所有权、交付物、范围或验收时才生成新 revision。
+
+- 当前波全部收口后才能修订；
+- revision 大于 1 时 `supersedes_revision` 指向直接上一版；
+- 语义不变沿用 unit ID，拆分使用新 ID，删除留空且不得复用；
+- 已派出的单元不能被静默改写；
+- 一次修订仍无法形成明确单元时，由主 Agent 接管或进入任务本来就需要的重型规划。
+
+Run envelope 使用：
+
+```json
+{
+  "team_plans": [],
+  "active_team_plan_revision": 1,
+  "workers": []
+}
+```
+
+Worker 记录用 `team_plan_revision + unit_id` 关联确切计划。微型模式把 envelope 留在上下文并从 stdin 校验；四个以上 Worker、多阶段、长时或需恢复时，写入现有 durable ledger。TeamPlan 不记录 Thread 控制状态。

--- a/skills/codex-model-routing-team/references/upstream-skill-adapter.md
+++ b/skills/codex-model-routing-team/references/upstream-skill-adapter.md
@@ -14,6 +14,7 @@
 
 本 Skill 拥有：
 
+- 把上游单元编译成轻量 TeamPlan 的 Worker、依赖、所有权、预算与集成顺序；不重写业务语义
 - Worker Surface、`model`、`thinking` 与 `speed`
 - RoutePlan、Provider allowlist、模型预检与 deterministic fallback
 - 原生 Subagent 的 fresh-context spawn、等待、follow-up 与关闭
@@ -26,14 +27,15 @@
 ## 调用流程
 
 1. 读取上游计划、任务账本、阶段门和输出路径。
-2. 接受上游已经完成的 Scale，不重新拆分任务。
-3. 计算当前阶段 Worker、后续阶段和重试的 reserved slots。
-4. 输出派遣通知，列明当前 Worker 的 Surface、模型、thinking、speed 与保留额度。
-5. 把上游任务转换成 `references/task-packet.md`，保留原始验收标准。
-6. 自动路由阶段默认使用 Luna XHigh/Max App Thread；只有用户明确要求原生，或 App 路径不可用且已预声明 fallback 时才使用原生 Subagent。
-7. 原生候选按 `references/native-subagent-lifecycle.md` 执行；App Thread 有工作区输出时绑定匹配 project local，并按 `references/thread-lifecycle.md` 与 `references/thread-supervision-protocol.md` 执行。
-8. 主 Agent 验证输出文件并更新上游账本。
-9. 只有上游阶段完成且结果采纳后，才关闭原生 Worker 或归档满足收尾门的 App Thread。
+2. 接受上游已经完成的 Scale 和业务单元，不重新拆分任务；按 [TeamPlan 协议](team-plan.md) 编译来源 ID、依赖、所有权、交付物和验收。
+3. 两个及以上 Worker 时从 stdin 运行 `scripts/validate_team_plan.py`；失败则修正一次、串行化或由主 Agent 接管，禁止调用第二套重型计划。
+4. 计算当前阶段 Worker、后续阶段和重试的 reserved slots。
+5. 输出派遣通知，列明当前 Worker 的 Surface、模型、thinking、speed 与保留额度。
+6. 把验证后的 unit 转换成 `references/task-packet.md`，保留原始验收标准与 `unit_id/team_plan_revision`。
+7. 自动路由阶段默认使用 Luna XHigh/Max App Thread；只有用户明确要求原生，或 App 路径不可用且已预声明 fallback 时才使用原生 Subagent。
+8. 原生候选按 `references/native-subagent-lifecycle.md` 执行；App Thread 有工作区输出时绑定匹配 project local，并按 `references/thread-lifecycle.md` 与 `references/thread-supervision-protocol.md` 执行。
+9. 主 Agent 验证输出文件并更新上游账本。
+10. 只有上游阶段完成且结果采纳后，才关闭原生 Worker 或归档满足收尾门的 App Thread。
 
 上游 run summary 的 Worker 记录按 Surface 分别遵守 [原生审计 schema](native-audit-schema.json) 或 [Thread 审计 schema](audit-schema.json)。每次创建使用唯一 task id 并递增 worker/subtask attempt；每次调用 `create_thread` 前另外写兼容字段 creation attempt，返回正式 id 或 pending id 后写入对应字段。`model` 继续作为 `requested_model` 的兼容别名。平台视图不保证返回模型字段，禁止依赖事后反查恢复路由信息。
 
@@ -59,6 +61,8 @@ researcher_count + 1 verifier + 1 reviewer + retry_reserve <= 8
   "worker_attempt": 1,
   "subtask_attempt": 1,
   "task_id": "deepresearch-topic-t1-a1",
+  "unit_id": "U1",
+  "team_plan_revision": 1,
   "surface": "app_thread",
   "creation_attempt": 1,
   "thread_id": null,

--- a/skills/codex-model-routing-team/references/validation-cases.md
+++ b/skills/codex-model-routing-team/references/validation-cases.md
@@ -22,6 +22,24 @@
 
 ## 最小行为回归
 
+### Net-positive TeamPlan
+
+Prompt：同时核对三个独立来源并汇总，任务不大，但 Luna Worker 并行预计更快且不降低验收质量。
+
+应出现：不以“任务不够复杂”为由拒绝；主 Agent 生成 3-unit 微型 TeamPlan，从 stdin 校验，计算单波派遣；每个 unit 有独立 output、ownership 和 done_when，再生成 Luna XHigh App RoutePlan 与 Task Packet；不创建 Planner 或持久文件。
+
+### TeamPlan write collision
+
+Prompt：两个实现 Worker 都计划修改 `scripts/router.py`，没有依赖关系。
+
+应出现：TeamPlan validator 拒绝同一就绪层写入冲突；主 Agent 增加依赖、重分所有权或串行执行，不能靠不同模型掩盖冲突。
+
+### Existing plan compiles, not rewrites
+
+Prompt：CE Plan 已定义 U1/U2、Dependencies、Files 和 Verification，请按模型路由团队执行。
+
+应出现：保留上游 U-ID 和业务质量门，只编译 TeamPlan 的 Worker、所有权、预算和集成顺序；不调用 `ce-work`，不重新写一份领域计划。
+
 ### Happy path
 
 Prompt：使用 Grok 4.5 实现复杂模块，再让另一个模型独立审查，最后由主 Agent 集成。
@@ -133,13 +151,15 @@ Prompt：一个 `task_intent=inspect` Worker 想顺手修改源文件，mutation
 - Grok 只在 runtime/provider 门通过后自动使用。
 - 每个新 `host/surface/model/thinking/speed/tool-signature` 的首个真实业务 Worker 独立通过对应生命周期健康门；一个组合的健康不外推到另一个组合。
 - 所有提示词含唯一 task id、task intent、mutation authority、完整任务包与禁止下级委派。
+- 两个及以上 Worker 派遣前必须有通过校验的 TeamPlan；每个 Worker 记录 `unit_id/team_plan_revision`，并恰好关联一份 Task Packet 和 RoutePlan。
+- 自动触发以净并行收益为准；`lead_only` 不构造完整 TeamPlan，微型 TeamPlan 不创建 Planner、不调用重型计划、不落持久文件。
 - `threadId`、`pendingWorktreeId`、超时和未知返回形状分别处理；排队 worktree 的身份/cwd 需要两次稳定官方观察。
 - 最新官方 Thread/turn 观察是当前状态真相；旧 status/event 文本只能诊断。
 - `UNKNOWN` 不 follow-up、不归档、不 fallback、不重复创建。
 - 同时运行不超过 6，worker attempts 不超过 8，任何 Worker 都不使用 Ultra。
 - 每个子任务最多两个 Worker attempt；完整输出最多在原 Worker follow-up 一次。
 - fallback 在派遣前固定，不随机选模、不形成循环、不静默改变 thinking/speed 或扩大 Provider allowlist。
-- 上游 Skill 模式保留上游 Scale、阶段门和输出路径；路由层不重复拆分任务。
+- 上游 Skill 模式保留上游 Scale、业务单元、阶段门和输出路径；路由层只编译 TeamPlan，不重复拆分或改写任务。
 - 有工作区输出路径时使用 project local，不因“通用调研”切换到 projectless。
 - Deep Research 默认最多 4 个 researcher，为 verifier、reviewer 和两次重试预留累计额度。
 - verifier 完成并产生 cited 文件后才能创建 reviewer。

--- a/skills/codex-model-routing-team/scripts/validate_team_ledger.py
+++ b/skills/codex-model-routing-team/scripts/validate_team_ledger.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from validate_team_plan import validate_team_plan_payload
+
 
 SKILL_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_SCHEMA = SKILL_ROOT / "references" / "audit-schema.json"
@@ -56,6 +58,26 @@ def valid_timestamp(value: Any) -> bool:
     except ValueError:
         return False
     return True
+
+
+def record_is_in_flight(record: dict[str, Any]) -> bool:
+    state = record.get("control_state")
+    if record.get("surface", "app_thread") == "native_subagent":
+        return state in {
+            "PLANNED",
+            "SPAWN_PENDING",
+            "RUNNING",
+            "COMPLETED",
+            "UNKNOWN",
+            "FAILED",
+        }
+    return state in {
+        "PLANNED",
+        "CREATION_PENDING",
+        "CONTROL_READY",
+        "DATA_READY",
+        "UNKNOWN",
+    }
 
 
 def nonempty_string(value: Any) -> bool:
@@ -151,6 +173,46 @@ def main() -> int:
         return 2
 
     result["record_count"] = len(records)
+    team_plan_units: dict[int, set[str]] = {}
+    active_team_plan_revision: int | None = None
+    if root is not None and (
+        "team_plans" in root or "active_team_plan_revision" in root
+    ):
+        team_plans = root.get("team_plans")
+        active_team_plan_revision = root.get("active_team_plan_revision")
+        if not isinstance(team_plans, list) or not team_plans:
+            result["errors"].append("root team_plans must be a non-empty array")
+        else:
+            revisions: list[int] = []
+            for index, team_plan in enumerate(team_plans):
+                validation = validate_team_plan_payload(team_plan)
+                if not validation["team_plan_valid"]:
+                    for error in validation["errors"]:
+                        result["errors"].append(
+                            f"team_plans[{index}] is invalid: {error}"
+                        )
+                    continue
+                revision = team_plan["revision"]
+                revisions.append(revision)
+                team_plan_units[revision] = {
+                    unit["unit_id"] for unit in team_plan["units"]
+                }
+            if revisions and revisions != list(range(1, len(revisions) + 1)):
+                result["errors"].append(
+                    "TeamPlan revisions must be ordered and contiguous from 1"
+                )
+            if (
+                not isinstance(active_team_plan_revision, int)
+                or isinstance(active_team_plan_revision, bool)
+                or active_team_plan_revision not in team_plan_units
+            ):
+                result["errors"].append(
+                    "active_team_plan_revision must name an available revision"
+                )
+            elif revisions and active_team_plan_revision != revisions[-1]:
+                result["errors"].append(
+                    "active_team_plan_revision must name the latest revision"
+                )
     surfaces = {
         record.get("surface", "app_thread")
         for record in records
@@ -189,6 +251,9 @@ def main() -> int:
     thread_ids: set[str] = set()
     pending_ids: set[str] = set()
     agent_ids: set[str] = set()
+    recorded_team_units: set[tuple[int, str]] = set()
+    in_flight_team_revisions: set[int] = set()
+    team_unit_attempts: dict[tuple[int, str], list[int]] = {}
     in_flight_states = {
         "PLANNED",
         "CREATION_PENDING",
@@ -204,6 +269,42 @@ def main() -> int:
             continue
 
         surface = record.get("surface", "app_thread")
+        if team_plan_units:
+            unit_id = record.get("unit_id")
+            team_plan_revision = record.get("team_plan_revision")
+            if not nonempty_string(unit_id):
+                result["errors"].append(f"{prefix} lacks a TeamPlan unit_id")
+            if (
+                not isinstance(team_plan_revision, int)
+                or isinstance(team_plan_revision, bool)
+                or team_plan_revision < 1
+            ):
+                result["errors"].append(
+                    f"{prefix} has invalid team_plan_revision"
+                )
+            elif team_plan_revision not in team_plan_units:
+                result["errors"].append(
+                    f"{prefix} references an unknown TeamPlan revision"
+                )
+            elif nonempty_string(unit_id):
+                if unit_id not in team_plan_units[team_plan_revision]:
+                    result["errors"].append(
+                        f"{prefix} references a unit outside its TeamPlan revision"
+                    )
+                else:
+                    pair = (team_plan_revision, unit_id)
+                    recorded_team_units.add(pair)
+                    subtask_attempt = record.get("subtask_attempt")
+                    if (
+                        isinstance(subtask_attempt, int)
+                        and not isinstance(subtask_attempt, bool)
+                        and 1 <= subtask_attempt <= 2
+                    ):
+                        team_unit_attempts.setdefault(pair, []).append(
+                            subtask_attempt
+                        )
+                    if record_is_in_flight(record):
+                        in_flight_team_revisions.add(team_plan_revision)
         if surface == "native_subagent":
             missing = [field for field in native_required if field not in record]
             if missing:
@@ -505,6 +606,31 @@ def main() -> int:
         result["errors"].append("Worker attempt values must be contiguous from 1")
     if result["in_flight_count"] > MAX_IN_FLIGHT:
         result["errors"].append("in-flight records exceed the concurrency cap")
+
+    if active_team_plan_revision is not None:
+        stale_in_flight = sorted(
+            revision
+            for revision in in_flight_team_revisions
+            if revision < active_team_plan_revision
+        )
+        if stale_in_flight:
+            result["errors"].append(
+                "a newer TeamPlan revision is active while an older revision is still in flight"
+            )
+
+    for (revision, unit_id), attempts_for_unit in sorted(team_unit_attempts.items()):
+        expected = list(range(1, len(attempts_for_unit) + 1))
+        if sorted(attempts_for_unit) != expected:
+            result["errors"].append(
+                f"TeamPlan revision {revision} unit {unit_id} attempts must be unique and contiguous from 1"
+            )
+
+    for revision, unit_ids in sorted(team_plan_units.items()):
+        for unit_id in sorted(unit_ids):
+            if (revision, unit_id) not in recorded_team_units:
+                result["warnings"].append(
+                    f"TeamPlan revision {revision} unit {unit_id} has no Worker record; report its disposition"
+                )
 
     if root is not None:
         expected_attempt_counts = {

--- a/skills/codex-model-routing-team/scripts/validate_team_plan.py
+++ b/skills/codex-model-routing-team/scripts/validate_team_plan.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+CURRENT_SCHEMA_VERSION = "1.0"
+MAX_PLANNED_WORKERS = 6
+MAX_WORKER_ATTEMPTS = 8
+MAX_NEW_WORKERS_PER_WAVE = 3
+PLANNING_SOURCES = {"ad_hoc", "codex_plan", "ce_plan", "upstream_skill"}
+ROLES = {"researcher", "implementer", "verifier", "reviewer", "custom"}
+UNIT_ID_PATTERN = re.compile(r"^U[1-9][0-9]*$")
+GLOB_CHARS = set("*?[]{}")
+
+
+def load_input(source: str) -> Any:
+    if source == "-":
+        return json.load(sys.stdin)
+    return json.loads(Path(source).read_text(encoding="utf-8"))
+
+
+def nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def valid_int(value: Any, *, minimum: int = 0) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= minimum
+
+
+def normalize_scope_path(value: Any) -> tuple[str | None, str | None]:
+    if not nonempty_string(value):
+        return None, "must be a non-empty string"
+    candidate = value.strip()
+    if "\\" in candidate:
+        return None, "must use forward slashes"
+    if any(char in candidate for char in GLOB_CHARS):
+        return None, "must not contain glob syntax"
+    path = PurePosixPath(candidate)
+    if path.is_absolute() or candidate == "." or ".." in path.parts:
+        return None, "must be a safe relative path"
+    normalized = path.as_posix().rstrip("/")
+    if not normalized:
+        return None, "must be a safe relative path"
+    return normalized, None
+
+
+def paths_overlap(left: str, right: str) -> bool:
+    left_parts = PurePosixPath(left).parts
+    right_parts = PurePosixPath(right).parts
+    shorter = min(len(left_parts), len(right_parts))
+    return left_parts[:shorter] == right_parts[:shorter]
+
+
+def validate_team_plan_payload(payload: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "status": "fail",
+        "team_plan_valid": False,
+        "schema_version": None,
+        "revision": None,
+        "worker_count": 0,
+        "dispatch_waves": [],
+        "errors": [],
+        "warnings": [],
+    }
+    errors: list[str] = result["errors"]
+
+    if not isinstance(payload, dict):
+        errors.append("TeamPlan must be a JSON object")
+        return result
+
+    schema_version = payload.get("schema_version")
+    revision = payload.get("revision")
+    result["schema_version"] = schema_version
+    result["revision"] = revision
+    if schema_version != CURRENT_SCHEMA_VERSION:
+        errors.append("unsupported TeamPlan schema_version")
+    if not valid_int(revision, minimum=1):
+        errors.append("revision must be a positive integer")
+    else:
+        supersedes = payload.get("supersedes_revision")
+        if revision == 1 and supersedes is not None:
+            errors.append("revision 1 must not supersede another revision")
+        if revision > 1 and supersedes != revision - 1:
+            errors.append("supersedes_revision must name the direct previous revision")
+
+    source = payload.get("planning_source")
+    source_refs = payload.get("source_refs")
+    if source not in PLANNING_SOURCES:
+        errors.append("planning_source is not supported")
+    if not isinstance(source_refs, list) or not all(
+        nonempty_string(item) for item in source_refs
+    ):
+        errors.append("source_refs must be an array of non-empty strings")
+    elif source != "ad_hoc" and not source_refs:
+        errors.append("non-ad_hoc TeamPlan requires source_refs")
+
+    if not nonempty_string(payload.get("root_goal")):
+        errors.append("root_goal must be a non-empty string")
+    if not nonempty_string(payload.get("revision_reason")):
+        errors.append("revision_reason must be a non-empty string")
+    if payload.get("integration_owner") != "lead":
+        errors.append("integration_owner must remain lead")
+    if not nonempty_string(payload.get("final_verification")):
+        errors.append("final_verification must be a non-empty string")
+
+    units = payload.get("units")
+    if not isinstance(units, list):
+        errors.append("units must be an array")
+        return result
+    result["worker_count"] = len(units)
+    if not 2 <= len(units) <= MAX_PLANNED_WORKERS:
+        errors.append("TeamPlan must contain between 2 and 6 Worker units")
+
+    reserved_slots = payload.get("reserved_slots")
+    if not valid_int(reserved_slots):
+        errors.append("reserved_slots must be a non-negative integer")
+    elif len(units) + reserved_slots > MAX_WORKER_ATTEMPTS:
+        errors.append("planned Workers plus reserved_slots exceed the attempt cap")
+
+    unit_order: list[str] = []
+    units_by_id: dict[str, dict[str, Any]] = {}
+    dependencies: dict[str, list[str]] = {}
+    write_scopes: dict[str, list[str]] = {}
+
+    for index, unit in enumerate(units):
+        prefix = f"unit {index}"
+        if not isinstance(unit, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        unit_id = unit.get("unit_id")
+        if not nonempty_string(unit_id) or UNIT_ID_PATTERN.fullmatch(unit_id) is None:
+            errors.append(f"{prefix} has invalid unit_id")
+            continue
+        if unit_id in units_by_id:
+            errors.append(f"{prefix} duplicates unit_id {unit_id}")
+            continue
+        unit_order.append(unit_id)
+        units_by_id[unit_id] = unit
+
+        if unit.get("role") not in ROLES:
+            errors.append(f"{unit_id} has unsupported role")
+        for field in ("goal", "output", "done_when"):
+            if not nonempty_string(unit.get(field)):
+                errors.append(f"{unit_id} has invalid {field}")
+
+        depends_on = unit.get("depends_on")
+        if not isinstance(depends_on, list) or not all(
+            nonempty_string(item) for item in depends_on
+        ):
+            errors.append(f"{unit_id} depends_on must contain unit IDs")
+            dependencies[unit_id] = []
+        else:
+            if len(depends_on) != len(set(depends_on)):
+                errors.append(f"{unit_id} duplicates dependencies")
+            if unit_id in depends_on:
+                errors.append(f"{unit_id} cannot depend on itself")
+            dependencies[unit_id] = list(depends_on)
+
+        ownership = unit.get("ownership")
+        if not isinstance(ownership, dict):
+            errors.append(f"{unit_id} ownership must be an object")
+            write_scopes[unit_id] = []
+            continue
+        normalized_scopes: dict[str, list[str]] = {"write": [], "forbidden": []}
+        for field in ("write", "forbidden"):
+            values = ownership.get(field)
+            if not isinstance(values, list):
+                errors.append(f"{unit_id} ownership.{field} must be an array")
+                continue
+            for value in values:
+                normalized, error = normalize_scope_path(value)
+                if error is not None:
+                    errors.append(f"{unit_id} ownership.{field} {error}")
+                elif normalized is not None:
+                    normalized_scopes[field].append(normalized)
+            if len(normalized_scopes[field]) != len(set(normalized_scopes[field])):
+                errors.append(f"{unit_id} ownership.{field} contains duplicates")
+        write_scopes[unit_id] = normalized_scopes["write"]
+        for write_path in normalized_scopes["write"]:
+            for forbidden_path in normalized_scopes["forbidden"]:
+                if paths_overlap(write_path, forbidden_path):
+                    errors.append(
+                        f"{unit_id} write scope overlaps its forbidden scope"
+                    )
+
+    if len(units_by_id) == len(units):
+        for unit_id, deps in dependencies.items():
+            for dependency in deps:
+                if dependency not in units_by_id:
+                    errors.append(f"{unit_id} depends on unknown unit {dependency}")
+
+        remaining = set(unit_order)
+        completed: set[str] = set()
+        layers: list[list[str]] = []
+        while remaining:
+            ready = [
+                unit_id
+                for unit_id in unit_order
+                if unit_id in remaining
+                and set(dependencies.get(unit_id, [])) <= completed
+            ]
+            if not ready:
+                errors.append("TeamPlan dependency graph contains a cycle")
+                break
+            layers.append(ready)
+            completed.update(ready)
+            remaining.difference_update(ready)
+
+        for layer in layers:
+            for left_index, left_id in enumerate(layer):
+                for right_id in layer[left_index + 1 :]:
+                    for left_path in write_scopes.get(left_id, []):
+                        for right_path in write_scopes.get(right_id, []):
+                            if paths_overlap(left_path, right_path):
+                                errors.append(
+                                    f"ready units {left_id} and {right_id} have overlapping write scope"
+                                )
+            for start in range(0, len(layer), MAX_NEW_WORKERS_PER_WAVE):
+                result["dispatch_waves"].append(
+                    layer[start : start + MAX_NEW_WORKERS_PER_WAVE]
+                )
+
+        integration_order = payload.get("integration_order")
+        if not isinstance(integration_order, list) or not all(
+            nonempty_string(item) for item in integration_order
+        ):
+            errors.append("integration_order must contain unit IDs")
+        elif len(integration_order) != len(set(integration_order)):
+            errors.append("integration_order contains duplicates")
+        elif set(integration_order) != set(unit_order):
+            errors.append("integration_order must cover every Worker unit exactly once")
+        else:
+            positions = {unit_id: index for index, unit_id in enumerate(integration_order)}
+            for unit_id, deps in dependencies.items():
+                for dependency in deps:
+                    if dependency in positions and positions[dependency] > positions[unit_id]:
+                        errors.append("integration_order violates dependency order")
+
+    if not errors:
+        result["status"] = "pass"
+        result["team_plan_valid"] = True
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate a lightweight TeamPlan before multi-Worker dispatch."
+    )
+    parser.add_argument("plan", help="TeamPlan JSON path, or - to read JSON from stdin")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        payload = load_input(args.plan)
+    except (OSError, json.JSONDecodeError) as exc:
+        result = {
+            "status": "fail",
+            "team_plan_valid": False,
+            "errors": [f"JSON load failed: {exc}"],
+            "warnings": [],
+        }
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 2
+    result = validate_team_plan_payload(payload)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result["team_plan_valid"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/codex-model-routing-team-expected.json
+++ b/tests/skills/codex-model-routing-team-expected.json
@@ -44,6 +44,10 @@
     "platform_accepted_speed",
     "observed_runtime_speed"
   ],
+  "team_plan_audit_fields": [
+    "unit_id",
+    "team_plan_revision"
+  ],
   "deep_research_budget": {
     "max_default_researchers": 4,
     "verifiers": 1,

--- a/tests/skills/test_codex_model_routing_team.py
+++ b/tests/skills/test_codex_model_routing_team.py
@@ -89,13 +89,18 @@ class SkillContractTests(unittest.TestCase):
         for field in contract["speed_audit_fields"]:
             self.assertIn(field, audit_schema["properties"])
             self.assertIn(field, native_schema["properties"])
+        for field in contract["team_plan_audit_fields"]:
+            self.assertIn(field, audit_schema["properties"])
+            self.assertIn(field, native_schema["properties"])
 
     def test_dual_surface_support_files_are_self_contained(self) -> None:
         required = (
             "references/native-audit-schema.json",
             "references/native-subagent-lifecycle.md",
             "references/surface-selection-policy.md",
+            "references/team-plan.md",
             "scripts/route_policy.py",
+            "scripts/validate_team_plan.py",
         )
         for relative in required:
             with self.subTest(relative=relative):
@@ -118,6 +123,8 @@ class SkillContractTests(unittest.TestCase):
             "Ultra",
             "UNKNOWN",
             "task_id",
+            "TeamPlan",
+            "scripts/validate_team_plan.py",
             "reserved slots",
             "单写者",
             "scripts/validate_route_plan.py",
@@ -138,8 +145,126 @@ class SkillContractTests(unittest.TestCase):
             "Surface selection",
             "Adjacent non-goal",
             "Regression",
+            "Net-positive TeamPlan",
+            "TeamPlan write collision",
         ):
             self.assertIn(case, cases)
+
+    def run_team_plan_validator(
+        self, plan: dict[str, object], *, stdin: bool = False
+    ) -> subprocess.CompletedProcess[str]:
+        command = [
+            sys.executable,
+            str(SKILL_ROOT / "scripts/validate_team_plan.py"),
+        ]
+        if stdin:
+            return subprocess.run(
+                [*command, "-"],
+                cwd=ROOT,
+                input=json.dumps(plan),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "team-plan.json"
+            path.write_text(json.dumps(plan), encoding="utf-8")
+            return subprocess.run(
+                [*command, str(path)],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def team_plan(
+        self,
+        *,
+        unit_count: int = 2,
+        revision: int = 1,
+        supersedes_revision: int | None = None,
+    ) -> dict[str, object]:
+        units = []
+        for index in range(1, unit_count + 1):
+            units.append(
+                {
+                    "unit_id": f"U{index}",
+                    "role": "researcher" if index < unit_count else "verifier",
+                    "goal": f"Complete bounded unit {index}",
+                    "output": f"reports/u{index}.md",
+                    "depends_on": [],
+                    "ownership": {
+                        "write": [f"reports/u{index}.md"],
+                        "forbidden": [],
+                    },
+                    "done_when": f"Unit {index} evidence is reviewable",
+                }
+            )
+        return {
+            "schema_version": "1.0",
+            "revision": revision,
+            "supersedes_revision": supersedes_revision,
+            "planning_source": "ad_hoc",
+            "source_refs": [],
+            "root_goal": "Deliver an integrated result",
+            "units": units,
+            "reserved_slots": 8 - unit_count,
+            "integration_owner": "lead",
+            "integration_order": [unit["unit_id"] for unit in units],
+            "final_verification": "Lead verifies the integrated result",
+            "revision_reason": "initial" if revision == 1 else "new dependency evidence",
+        }
+
+    def test_team_plan_validator_accepts_stdin_and_computes_waves(self) -> None:
+        plan = self.team_plan(unit_count=4)
+        plan["reserved_slots"] = 4
+        result = self.run_team_plan_validator(plan, stdin=True)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["team_plan_valid"])
+        self.assertEqual(payload["dispatch_waves"], [["U1", "U2", "U3"], ["U4"]])
+
+    def test_team_plan_validator_respects_dependency_layers(self) -> None:
+        plan = self.team_plan(unit_count=3)
+        plan["reserved_slots"] = 5
+        plan["units"][2]["depends_on"] = ["U1", "U2"]
+        result = self.run_team_plan_validator(plan)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(
+            json.loads(result.stdout)["dispatch_waves"],
+            [["U1", "U2"], ["U3"]],
+        )
+
+    def test_team_plan_validator_rejects_cycle_and_same_wave_write_overlap(self) -> None:
+        cyclic = self.team_plan()
+        cyclic["units"][0]["depends_on"] = ["U2"]
+        cyclic["units"][1]["depends_on"] = ["U1"]
+        cycle_result = self.run_team_plan_validator(cyclic)
+        self.assertEqual(cycle_result.returncode, 2, cycle_result.stdout)
+        self.assertIn("contains a cycle", cycle_result.stdout)
+
+        overlap = self.team_plan()
+        overlap["units"][0]["ownership"]["write"] = ["scripts"]
+        overlap["units"][1]["ownership"]["write"] = ["scripts/router.py"]
+        overlap_result = self.run_team_plan_validator(overlap)
+        self.assertEqual(overlap_result.returncode, 2, overlap_result.stdout)
+        self.assertIn("overlapping write scope", overlap_result.stdout)
+
+    def test_team_plan_validator_rejects_budget_and_lead_ownership_drift(self) -> None:
+        plan = self.team_plan(unit_count=6)
+        plan["reserved_slots"] = 3
+        plan["integration_owner"] = "worker"
+        result = self.run_team_plan_validator(plan)
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("exceed the attempt cap", result.stdout)
+        self.assertIn("integration_owner must remain lead", result.stdout)
+
+    def test_team_plan_validator_requires_upstream_source_refs(self) -> None:
+        plan = self.team_plan()
+        plan["planning_source"] = "ce_plan"
+        result = self.run_team_plan_validator(plan)
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("requires source_refs", result.stdout)
 
     def run_preflight(self, *args: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
@@ -1131,6 +1256,142 @@ class SkillContractTests(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertTrue(payload["ledger_valid"])
         self.assertEqual(payload["in_flight_count"], 1)
+
+    def test_ledger_validator_maps_workers_to_team_plan_units(self) -> None:
+        plan = self.team_plan()
+        first = self.ledger_record(unit_id="U1", team_plan_revision=1)
+        second = self.ledger_record(
+            creation_attempt=2,
+            task_id="task-beta-a1",
+            thread_id="thread-beta",
+            unit_id="U2",
+            team_plan_revision=1,
+        )
+        result = self.run_ledger_validator(
+            {
+                "team_plans": [plan],
+                "active_team_plan_revision": 1,
+                "creation_attempts": 2,
+                "worker_attempts": 2,
+                "workers": [first, second],
+            }
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["ledger_valid"])
+        self.assertEqual(payload["warnings"], [])
+
+    def test_ledger_validator_rejects_worker_outside_team_plan(self) -> None:
+        result = self.run_ledger_validator(
+            {
+                "team_plans": [self.team_plan()],
+                "active_team_plan_revision": 1,
+                "workers": [
+                    self.ledger_record(unit_id="U9", team_plan_revision=1)
+                ],
+            }
+        )
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("outside its TeamPlan revision", result.stdout)
+
+    def test_ledger_validator_blocks_new_revision_while_old_wave_is_active(self) -> None:
+        revision_one = self.team_plan()
+        revision_two = self.team_plan(revision=2, supersedes_revision=1)
+        old_active = self.ledger_record(
+            unit_id="U1",
+            team_plan_revision=1,
+            control_state="DATA_READY",
+            thread_status="active",
+            turn_status="inProgress",
+            output=None,
+            adopted=False,
+            archived=False,
+        )
+        new_planned = self.ledger_record(
+            creation_attempt=2,
+            task_id="task-new-revision-a1",
+            unit_id="U1",
+            team_plan_revision=2,
+            thread_id=None,
+            control_state="PLANNED",
+            thread_status=None,
+            turn_status=None,
+            last_observed_at=None,
+            materialized=False,
+            data_ready=False,
+            status="planned",
+            output=None,
+            adopted=False,
+            archived=False,
+        )
+        result = self.run_ledger_validator(
+            {
+                "team_plans": [revision_one, revision_two],
+                "active_team_plan_revision": 2,
+                "workers": [old_active, new_planned],
+            }
+        )
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("older revision is still in flight", result.stdout)
+
+    def test_ledger_validator_blocks_activating_revision_before_old_wave_closes(self) -> None:
+        result = self.run_ledger_validator(
+            {
+                "team_plans": [
+                    self.team_plan(),
+                    self.team_plan(revision=2, supersedes_revision=1),
+                ],
+                "active_team_plan_revision": 2,
+                "workers": [
+                    self.ledger_record(
+                        unit_id="U1",
+                        team_plan_revision=1,
+                        control_state="DATA_READY",
+                        thread_status="active",
+                        turn_status="inProgress",
+                        output=None,
+                        adopted=False,
+                        archived=False,
+                    )
+                ],
+            }
+        )
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("older revision is still in flight", result.stdout)
+
+    def test_ledger_validator_enforces_two_contiguous_attempts_per_unit(self) -> None:
+        first = self.ledger_record(unit_id="U1", team_plan_revision=1)
+        duplicate = self.ledger_record(
+            creation_attempt=2,
+            task_id="task-alpha-a2",
+            thread_id="thread-alpha-a2",
+            unit_id="U1",
+            team_plan_revision=1,
+            subtask_attempt=1,
+        )
+        result = self.run_ledger_validator(
+            {
+                "team_plans": [self.team_plan()],
+                "active_team_plan_revision": 1,
+                "workers": [first, duplicate],
+            }
+        )
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("attempts must be unique and contiguous", result.stdout)
+
+    def test_ledger_validator_warns_for_undispatched_team_plan_unit(self) -> None:
+        result = self.run_ledger_validator(
+            {
+                "team_plans": [self.team_plan()],
+                "active_team_plan_revision": 1,
+                "workers": [
+                    self.ledger_record(unit_id="U1", team_plan_revision=1)
+                ],
+            }
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        warnings = json.loads(result.stdout)["warnings"]
+        self.assertTrue(any("unit U2 has no Worker record" in item for item in warnings))
 
     def test_ledger_validator_rejects_unknown_archive_and_pending_as_thread(self) -> None:
         invalid = self.ledger_record(


### PR DESCRIPTION
## What changed

- add a lightweight TeamPlan 1.0 contract and dependency-free validator before every two-or-more-Worker dispatch
- validate dependencies, same-wave write ownership, attempt budgets, integration order, plan revisions, and lead-only final verification
- compile CE Plan, Codex Plan, and upstream Skill decomposition without rewriting domain plans
- bind Worker ledger records to `unit_id` and `team_plan_revision`
- update bilingual documentation, trigger evals, Registry metadata, and the Skill contract

## Why

The router already selected models and supervised Workers, but it did not provide a stable, machine-checkable decomposition layer. TeamPlan makes assignment and integration deterministic while keeping ordinary 2–3 Worker tasks lightweight.

## Impact

Parallel work now activates on clear net benefit rather than vague complexity. Luna App Thread routing, Luna-only Fast, Sol High+, Provider gates, and existing fallback rules remain unchanged.

## Validation

- `python3 -m unittest tests.skills.test_codex_model_routing_team -v` — 56 passed
- `python3 -m unittest discover -s tests -v` — 91 passed
- Portfolio Skill validation — clear, 0 blockers / 0 warnings
- isolated install — 29 files matched byte-for-byte
- Yao Production gates — 0 failures / 0 warnings, 970/1000 initial-load tokens
- trigger eval — 10/10, precision 1.0, recall 1.0