### PR TITLE
Optimize Fast routing and adaptive Worker limits

### DIFF
--- a/docs/changelogs/codex-model-routing-team.md
+++ b/docs/changelogs/codex-model-routing-team.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Separate Fast eligibility from default preference: Luna defaults to Fast when live `service_tier=priority` evidence exists, while Sol and Terra default to Standard but may use explicit Fast when the current Surface proves the exact tuple.
+- Replace the fixed 6/8/3 ceiling with registry-backed TeamPlan profiles: conservative `standard` remains the default, while justified, ownership-isolated, host-confirmed `expanded` runs may use 12 concurrent Workers, 16 root attempts, and 6 new Workers per wave with at least two reserved slots.
 - Add a lightweight TeamPlan compiler and dependency-free validator before every two-or-more-Worker dispatch, covering dependencies, same-wave ownership conflicts, budgets, integration order, and lead-only final verification.
 - Compile CE Plans, Codex Plans, and upstream Skill decompositions without rewriting them; keep two-to-three-unit micro plans in context and persist only durable four-plus-Worker or resumable runs.
 - Bind Worker ledger entries to `team_plan_revision` and `unit_id`, reject mid-wave structural revisions and plan-external Workers, and warn when valid units remain undispatched.
@@ -9,7 +11,7 @@
 - Make `speed` a versioned RoutePlan dimension with backward-compatible legacy Standard behavior.
 - Default automatic routing to Luna XHigh App Thread, raise difficult or high-risk tasks to Luna Max, and keep native V2 only for explicit requests or predeclared fallback.
 - Treat Luna as App-only while the official native V2 live schema omits it; require Sol High or stronger on every Surface and reject Sol Medium/Low even when explicitly requested.
-- Require live `create_thread` speed evidence for App Luna Fast; keep Sol, Terra, and other models on Standard while preserving separate requested/accepted/observed speed audit fields.
+- Require tuple-bound live speed evidence for every Fast route while preserving separate requested/accepted/observed speed audit fields.
 - Slim initial Skill/interface context from 1708 to 890 estimated tokens by keeping only triggers, branch selection, the shared execution skeleton, hard gates, and the output contract; defer detailed policy and lifecycle rules to existing references.
 
 ## 2.1.0 — 2026-07-27

--- a/docs/skills/codex-model-routing-team/README.md
+++ b/docs/skills/codex-model-routing-team/README.md
@@ -58,8 +58,8 @@ To let Codex activate the Skill automatically for suitable complex work, add the
 - Before creating two or more Workers, the lead must compile a lightweight TeamPlan. Existing CE Plans, Codex Plans, and upstream Skill plans are compiled rather than rewritten. TeamPlan does not create a separate Planner, enter a heavyweight planning flow, or persist files by default.
 - The lead agent keeps its current model and owns planning, file ownership, integration, verification, and final delivery.
 - Use App threads by default. Native subagents are explicit-request or predeclared-fallback only because the current official V2 live schema does not expose Luna.
-- Run at most 6 Workers concurrently and make at most 8 Worker attempts for one root task; failures, non-materialized calls, and fallbacks count. Workers must not create more Workers or subagents.
-- Workers must not use Ultra. Terra is opt-in and excluded from automatic routing. Luna is App-only and starts at XHigh; Sol starts at High on every surface. Only App Luna may request Fast, with live `service_tier=priority` evidence; Sol and Terra remain Standard. Unavailable combinations follow only a predeclared fallback or return to the lead agent.
+- Use the Standard TeamPlan profile by default: at most 6 concurrent Workers, 8 root attempts, and 3 new Workers per wave. For 7–12 independently verifiable outputs with isolated ownership and confirmed host capacity, an explicit `expanded` profile may use 12/16/6 and must retain at least two reserved slots. Workers must not create more Workers or subagents.
+- Workers must not use Ultra. Terra is opt-in and excluded from automatic routing. Luna is App-only and starts at XHigh. Luna defaults to Fast when live `service_tier=priority` evidence exists; Sol and Terra default to Standard and may use Fast only on explicit user request with matching live evidence. Unavailable combinations follow only a predeclared fallback or return to the lead agent.
 - Do not auto-dispatch simple questions, status checks, small single-file edits, strongly sequential work, publishing, sending, payment, deletion, account, or production operations.
 ```
 
@@ -77,10 +77,10 @@ Ordinary automatic groups use the governed App-thread path. `native-light` is re
 
 - Uses a net-benefit gate: at least two independently verifiable deliverables, with expected savings greater than coordination cost; otherwise the lead executes directly.
 - Requires and validates a lightweight TeamPlan before dispatching two or more Workers, while compiling existing plans without rewriting them.
-- Defaults to Luna XHigh App threads and raises difficult or high-risk work to Luna Max. Native Luna is rejected; Sol is High/XHigh/Max only and remains Standard. App Luna may use Fast only when the live create schema accepts `service_tier=priority`; Grok 4.5 stays conditional on runtime/provider preflight.
+- Defaults to Luna XHigh App Fast and raises difficult or high-risk work to Luna Max Fast; either becomes Standard when live priority evidence is absent. Native Luna is rejected. Sol is High/XHigh/Max only, defaults to Standard, and accepts explicit Fast only with matching live evidence. Grok 4.5 stays conditional on runtime/provider preflight.
 - Keeps `gpt-5.6-terra` opt-in and first-candidate-only. An unknown-model response fails that exact native route and never silently inherits the parent model.
 - Retains explicit Gemini 3.6 Flash route templates while blocking the current third-party Antigravity login path; an official API/Vertex path needs a separate registry entry.
-- Limits fan-out to three new Workers per wave, six concurrent Workers, and eight Worker attempts per root request across both surfaces.
+- Keeps a conservative Standard 6/8/3 profile, with a justified Expanded 12/16/6 profile for many isolated deliverables. The narrower live host limit always wins.
 - Uses the first business task for each model/reasoning/speed/tool signature as its final health probe, separating HTTP, thread materialization, model data, and delivery quality.
 - Separates formal `threadId`, queued `pendingWorktreeId`, transport timeout, and ambiguous state; a unique task id recovers queued work, while `UNKNOWN` blocks follow-up, archival, fallback, and duplicate creation.
 - Treats the latest official Thread/turn read as current truth and uses a minimal ledger validator for attempt, materialization, DATA_READY, and archive invariants.
@@ -112,7 +112,7 @@ printf '%s' "$TEAM_LEDGER_JSON" | python3 scripts/validate_team_ledger.py -
 
 When an upstream Skill already owns decomposition, this Skill compiles those units into TeamPlan while preserving stages, artifacts, and quality gates. It does not invent a second domain plan. Any task with a workspace output path is project-bound; only chat-only work may be projectless.
 
-The default Deep Research budget is `2-4 researchers + 1 verifier + 1 reviewer + 2 retry slots`, within the cumulative eight-task cap.
+The default Deep Research budget remains `2-4 researchers + 1 verifier + 1 reviewer + 2 retry slots` in the Standard profile. Expanded routing is reserved for genuinely independent outputs, not ordinary research breadth.
 
 ## Example requests
 
@@ -158,7 +158,7 @@ The agent workflow lives in [SKILL.md](../../../skills/codex-model-routing-team/
 
 ## Validation
 
-The workflow covers net-benefit selection; TeamPlan dependency layers, same-wave write conflicts, budget, revisions, and unplanned Worker detection; App-first Luna XHigh/Max routing; Native Luna and Sol Medium/Low rejection; speed audit; queued-worktree recovery; mixed ledgers; and isolated `npx skills` installation.
+The workflow covers net-benefit selection; Standard/Expanded TeamPlan limits, dependency layers, same-wave write conflicts, budgets, revisions, and unplanned Worker detection; default Luna Fast versus explicit Sol/Terra Fast; Native Luna and Sol Medium/Low rejection; speed audit; queued-worktree recovery; mixed ledgers; and isolated `npx skills` installation.
 
 ## License
 

--- a/docs/skills/codex-model-routing-team/README.zh-CN.md
+++ b/docs/skills/codex-model-routing-team/README.zh-CN.md
@@ -58,8 +58,8 @@ find ~/.agents/skills/codex-model-routing-team -maxdepth 2 -type f | sort
 - 准备创建两个以上 Worker 时，主 Agent 必须先生成轻量 TeamPlan；已有 CE Plan、Codex Plan 或上游 Skill 计划时只编译、不重写。TeamPlan 默认不创建独立 Planner、不进入重型规划流程、不写持久文件。
 - 主 Agent 保持当前模型，负责规划、文件所有权、集成、验证和最终交付。
 - 默认使用 App Thread。当前官方 V2 live schema 不开放 Luna，原生 Subagent 只用于用户明确点名或预声明 fallback。
-- 跨 Surface 同时运行最多 6 个 Worker；单个根任务累计最多 8 次 Worker attempt，失败、未实体化和 fallback 都计数。Worker 不得继续创建任何后台任务或子 Agent。
-- Worker 禁止使用 Ultra；Terra 为 opt-in，默认不参与自动路由。Luna 只走 App Thread 且最低 XHigh，Sol 在任一 Surface 都最低 High。只有 App Luna 可在 live schema 接受 `service_tier=priority` 时请求 Fast，Sol/Terra 保持 Standard。不可用时只走预声明 fallback 或由主 Agent 接管。
+- 默认使用 TeamPlan `standard` 档：跨 Surface 并发 6、根任务累计 8 次 attempts、每波新增 3。只有 7–12 个独立可验收产物、所有权隔离且 live host 容量允许时，才显式使用 `expanded` 12/16/6，并至少保留 2 个 reserved slots。Worker 不得继续创建任何后台任务或子 Agent。
+- Worker 禁止使用 Ultra；Terra 为 opt-in，默认不参与自动路由。Luna 只走 App Thread 且最低 XHigh；有 live `service_tier=priority` 证据时默认 Fast。Sol 在任一 Surface 都最低 High，Sol/Terra 默认 Standard，仅在用户明确要求且 live schema 接受精确组合时使用 Fast。不可用时只走预声明 fallback 或由主 Agent 接管。
 - 简单问答、状态查询、单文件小改、强顺序任务以及发布、发送、付款、删除、账户或生产操作不自动派遣。
 ```
 
@@ -77,10 +77,10 @@ find ~/.agents/skills/codex-model-routing-team -maxdepth 2 -type f | sort
 
 - 用净收益门判断是否派遣：至少两个单元拥有独立交付物与完成条件，且节省高于协调成本；否则由主 Agent 直接完成。
 - 两个以上 Worker 必须先编译并校验轻量 TeamPlan，明确依赖、写入所有权、交付物、验收和集成顺序；已有计划只编译、不重写。
-- 默认使用 Luna XHigh App Thread，高难或高风险任务升 Luna Max。Native Luna 静态拒绝；Sol 仅允许 High/XHigh/Max 且始终 Standard。App Luna 只有在 live create schema 接受 `service_tier=priority` 时才使用 Fast；Grok 4.5 在 runtime/provider 预检后承担复杂执行和异构审查。
+- 默认使用 Luna XHigh App Fast，高难或高风险任务升 Luna Max Fast；缺少 live priority 证据时改为 Standard。Native Luna 静态拒绝；Sol 仅允许 High/XHigh/Max，默认 Standard，显式 Fast 必须有匹配的 live 证据。Grok 4.5 在 runtime/provider 预检后承担复杂执行和异构审查。
 - `gpt-5.6-terra` 为 opt-in，只能作为用户明确点名的首项候选；unknown model 只判定该精确原生组合失败，禁止静默继承父模型。
 - Gemini 3.6 Flash 保留显式路由模板，但当前 Antigravity 第三方登录路径受官方条款阻断；正式 API/Vertex 路径需要新的 registry entry。
-- 每波最多新增 3 个 Worker，跨 Surface 同时运行最多 6 个，单个根任务累计最多 8 次 Worker attempt。
+- 保留稳健的默认 6/8/3 档；大量互斥交付物可在写入隔离、扩容理由和 live host 容量门通过后使用 12/16/6。实际运行时上限更窄时，以更窄上限为准。
 - 每个新模型/推理强度/速度/工具签名组合的首个真实业务任务充当健康探针；HTTP 成功、Thread 实体化、模型数据事件和交付质量分别验收。
 - 区分正式 `threadId`、排队 `pendingWorktreeId`、超时和歧义状态；用唯一 task id 恢复排队任务，`UNKNOWN` 状态禁止追问、归档、fallback 和重复创建。
 - 以最新官方 Thread/turn 读取作为当前状态真相，通过最小 ledger validator 检查 attempt、实体化、DATA_READY 与归档不变量。
@@ -112,7 +112,7 @@ printf '%s' "$TEAM_LEDGER_JSON" | python3 scripts/validate_team_ledger.py -
 
 上游 Skill 已经完成任务拆分时，本 Skill把现有单元编译为 TeamPlan，保留其阶段顺序、产物和质量门，不再猜一套计划。声明工作区输出路径的任务始终绑定项目；只有纯聊天交付才能使用 projectless。
 
-Deep Research 默认预算为 `2-4 个 researcher + 1 个 verifier + 1 个 reviewer + 2 个重试位`，总数不超过 8 个。
+Deep Research 默认仍使用 `2-4 个 researcher + 1 个 verifier + 1 个 reviewer + 2 个重试位` 的 standard 档；普通调研广度不自动触发 expanded。
 
 ## 使用示例
 
@@ -158,7 +158,7 @@ Agent 的完整工作流见 [SKILL.md](../../../skills/codex-model-routing-team/
 
 ## 验证情况
 
-工作流已经覆盖净收益判断、TeamPlan 依赖层、同波写冲突、预算、修订和计划外 Worker 校验，以及 App-first Luna XHigh/Max、Native Luna 与 Sol Medium/Low 的静态拒绝、速度审计、pending worktree 恢复、混合 ledger 和隔离 `npx skills` 安装。
+工作流已经覆盖净收益判断、standard/expanded 档位、TeamPlan 依赖层、同波写冲突、预算、修订和计划外 Worker 校验，以及默认 Luna Fast 与显式 Sol/Terra Fast、Native Luna 与 Sol Medium/Low 的静态拒绝、速度审计、pending worktree 恢复、混合 ledger 和隔离 `npx skills` 安装。
 
 ## 许可证
 

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -61,7 +61,7 @@
         "commands": [
           "python3 -m unittest tests.skills.test_codex_model_routing_team -v"
         ],
-        "live_smoke": "Validate a two-unit TeamPlan before dispatch, run one Luna XHigh App thread canary, confirm native V2 rejects or omits Luna, and confirm Sol Medium is statically rejected while Sol High remains eligible; record TeamPlan unit/revision and requested, accepted, and observed model and speed identity separately"
+        "live_smoke": "Validate both a standard two-unit TeamPlan and a justified expanded TeamPlan; run one Luna XHigh App Fast canary with live priority evidence, confirm native V2 rejects or omits Luna, confirm Sol Medium is rejected, and confirm Sol Fast requires explicit request plus tuple-bound live evidence; record TeamPlan profile/unit/revision and requested, accepted, and observed model and speed identity separately"
       },
       "capabilities": {
         "network": "required",

--- a/skills/codex-model-routing-team/SKILL.md
+++ b/skills/codex-model-routing-team/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: codex-model-routing-team
-description: 为存在明确净并行收益的任务编译轻量 TeamPlan，默认创建 Luna XHigh/Max Codex App Thread，并在 live schema 支持时使用原生 fallback。用于两个以上有独立交付物的工作流、来源/章节/模块、独立验证，或用户明确要求模型路由、后台 Worker、Agents Team、Grok/Gemini Worker。简单问答、状态查询、单文件小改、强顺序任务和不可逆操作不自动触发。
+description: 为有明确净并行收益的任务编译 TeamPlan，默认创建 Luna XHigh/Max App Thread，并在 live schema 支持时使用原生 fallback。用于两个以上独立交付物、独立验证，或用户明确要求模型路由、后台 Worker、Agents Team、Grok/Gemini Worker。简单问答、状态查询、单文件小改、强顺序任务和不可逆操作不自动触发。
 ---
 
 # Codex 模型路由团队
 
-主 Agent 保持当前模型并负责规划、文件所有权、集成和验收。两个以上 Worker 先编译轻量 TeamPlan；默认路由为 `app_thread/gpt-5.6-luna/xhigh`，高难/高风险升 `max`；`native_subagent` 只用于显式请求或预声明 fallback。
+主 Agent 保持模型并负责规划、所有权、集成和验收。两个以上 Worker 先编译 TeamPlan；默认 `app_thread/gpt-5.6-luna/xhigh/fast`，高风险升 `max`，无 live 证据则 Standard；`native_subagent` 仅显式或 fallback。
 
 ## 不使用
 
@@ -13,7 +13,7 @@ description: 为存在明确净并行收益的任务编译轻量 TeamPlan，默�
 
 ## 执行模式
 
-- `governed`（默认）：主 Agent 一次编译 2–3 unit 微型 TeamPlan，Luna App Thread 从 XHigh 起步；TeamPlan/RoutePlan/ledger 从 stdin 校验，需要恢复/worktree/审计时按 [耐久模式](references/durable-mode.md) 留状态。
+- `governed`（默认）：编译 2–3 unit 微型 TeamPlan，Luna App 从 XHigh 起步；三类 JSON 从 stdin 校验，需要恢复/worktree/审计时按 [耐久模式](references/durable-mode.md) 留状态。
 - `native-light`（显式/回退）：App 不可用时须预声明；Luna 不可走原生，Sol 最低 High。
 - 上游 Skill 已定义拆分、阶段和产物时，遵守 [适配协议](references/upstream-skill-adapter.md)，不重做 Scale、阶段门或第二套账本。
 
@@ -25,7 +25,7 @@ description: 为存在明确净并行收益的任务编译轻量 TeamPlan，默�
 4. 每个 unit 生成 `schema_version: "2.1"` RoutePlan 并运行 `scripts/validate_route_plan.py`。原生组合必须有 live `runtime_evidence`；App Fast 必须有 live `speed_evidence`。
 5. 按 [任务包](references/task-packet.md) 写 `unit_id/team_plan_revision`、唯一 `task_id`、权限、验收和禁止下级派遣；派遣前简报 Worker 数、精确路由、职责、fallback 与 reserved slots。
 6. 原生路径遵守 [生命周期](references/native-subagent-lifecycle.md)；App 路径遵守 [Thread 生命周期](references/thread-lifecycle.md) 与 [监督协议](references/thread-supervision-protocol.md)。
-7. 跨 Surface 并发最多 6、根任务累计 8 次 Worker attempt、每波新增最多 3；每 unit 最多 2 次 attempt、原 Worker 最多一次 follow-up，并保持单写者。
+7. TeamPlan 默认 `standard` 6/8/3；独立产物足够多且扩容收益、隔离与 host 容量明确时可用 `expanded` 12/16/6，并留至少 2 个 reserved slots。每 unit 最多 2 次 attempt、一次 follow-up，保持单写者；更窄 live 上限优先。
 8. 失败只按 [恢复策略](references/recovery-policy.md) 沿预声明链前进；只有依赖、所有权、交付物、范围或验收发生结构变化时，才在当前波收口后修订 TeamPlan。
 9. 主 Agent 验证并集成交付，关闭已采纳原生 Worker，仅归档满足收尾门的 App Thread；运行 `scripts/validate_team_ledger.py` 后汇报 TeamPlan、路由、尝试、fallback、采纳与收尾状态。
 
@@ -33,10 +33,10 @@ description: 为存在明确净并行收益的任务编译轻量 TeamPlan，默�
 
 - registry 决定策略允许范围；live schema 只证明当前 host 接受精确组合。请求、平台接受与 observed 模型/速度必须分开记录，未回显保持 `unknown`。
 - 官方原生 V2 live schema 未开放 Luna；Luna 仅走 App Thread，XHigh 起步，高难/高风险 Max。Sol 无论 Surface 均最低 High；Medium/Low 静态拒绝。
-- Fast 是 `service_tier=priority`，不是模型 ID；只有 Luna 可用，Sol、Terra 和其他模型一律 Standard。App Surface 未显式接受速度参数时 Luna 保持 Standard，不得声称 Fast。
+- Fast 即 `service_tier=priority`。Luna 默认 Fast；Sol/Terra 默认 Standard，仅在用户明确要求且 live schema 接受精确组合时用 Fast。无证据一律 Standard。
 - Terra 仅在用户点名时作为首项；Grok 须通过 runtime/provider 门；Gemini Antigravity 当前 blocked。禁止自动使用旧模型、Ultra 或低于最低 `thinking` 的 fallback。
 - Worker 不得继续派生任务，也不得执行发布、发送、付款、删除、账户或生产变更。主 Agent 不切换自身模型。
-- TeamPlan 默认不创建 Planner、不调用重型计划、不落持久文件；同波写冲突、依赖环、超预算、计划外 Worker 或下放最终验收必须拒绝。
+- TeamPlan 默认不创建 Planner、不调用重型计划、不落持久文件；`expanded` 必须写 `scale_reason` 并保留故障位；同波写冲突、依赖环、超预算、计划外 Worker 或下放最终验收必须拒绝。
 - `pendingWorktreeId`/未知返回值不可管理；零或多匹配进入 `UNKNOWN`，禁止追问、归档、fallback、重复创建或修改 Codex 数据库。上游阶段门始终优先。
 
 ## 输出契约

--- a/skills/codex-model-routing-team/agents/interface.yaml
+++ b/skills/codex-model-routing-team/agents/interface.yaml
@@ -17,4 +17,4 @@ compatibility:
     remote_inline_execution: "forbid"
     remote_metadata_policy: "deny"
   degradation:
-    openai: "Use Luna XHigh/Max App threads. Native V2 is explicit/fallback only; Sol starts at High. Luna Fast requires service_tier=priority."
+    openai: "Default to Luna XHigh/Max App Fast when live priority evidence exists. Sol/Terra default Standard but may use explicit Fast with live evidence. TeamPlan scales from standard 6/8/3 to justified expanded 12/16/6."

--- a/skills/codex-model-routing-team/evals/model-routing-recovery.json
+++ b/skills/codex-model-routing-team/evals/model-routing-recovery.json
@@ -72,14 +72,14 @@
       "expected_output": "App Thread 保持 Standard；不得声称 Fast。强制 App Fast 的 RoutePlan 因缺少 tuple-bound speed_evidence 被拒绝。"
     },
     {
-      "id": "sol-fast-static-rejection",
+      "id": "sol-fast-explicit-gate",
       "prompt": "让 Sol XHigh 使用原生 Fast。",
-      "expected_output": "静态拒绝 RoutePlan；Sol 只允许 Standard，Fast 自动路由只允许 Luna。"
+      "expected_output": "自动 RoutePlan 静态拒绝，因为 Sol 默认 Standard；只有用户明确要求且当前原生 live schema 接受 service_tier=priority 时才允许 Sol XHigh Fast。"
     },
     {
       "id": "native-light-four-short-outputs",
       "prompt": "四个互斥的小文件预计十分钟完成，明确交给三个 Sol High 原生 Worker，结果回到父任务集成。",
-      "expected_output": "因显式原生请求选择 native-light；不创建 agent_team；仍执行 Provider、Sol High 下限、6/8、单写者、fresh-context 和关闭门。"
+      "expected_output": "因显式原生请求选择 native-light；不创建 agent_team；仍执行 Provider、Sol High 下限、默认 6/8/3、单写者、fresh-context 和关闭门。"
     },
     {
       "id": "native-terra-rejected",
@@ -89,7 +89,12 @@
     {
       "id": "surface-selection-durable",
       "prompt": "并行做一个五分钟只读检查，以及一个需要独立 worktree、跨会话恢复的实现任务。",
-      "expected_output": "两个任务默认都选 app_thread；普通检查使用 Luna XHigh，worktree 实现按风险使用 Luna XHigh/Max；两者共享并发 6、累计 attempts 8 和单写者上限。"
+      "expected_output": "两个任务默认都选 app_thread；普通检查使用 Luna XHigh，worktree 实现按风险使用 Luna XHigh/Max；使用标准 6/8/3 档并保持单写者。"
+    },
+    {
+      "id": "expanded-team-plan",
+      "prompt": "12 个互不依赖的审核对象，各自产出独立报告，主 Agent 统一汇总；当前 host 能承载 6 个并发 Worker。",
+      "expected_output": "记录 scale_reason，验证所有权隔离，选择 expanded 12/16/6 并保留至少两个 reserved slots；实际 host 上限更窄时降低每波数量。"
     },
     {
       "id": "terra-cannot-be-fallback",

--- a/skills/codex-model-routing-team/evals/upstream-skill-integration.json
+++ b/skills/codex-model-routing-team/evals/upstream-skill-integration.json
@@ -19,7 +19,7 @@
     {
       "id": "pure-chat-projectless",
       "prompt": "并行查询三个独立事实，只在聊天中返回结果，不写任何工作区文件。",
-      "expected_output": "允许 projectless；仍执行实体化健康探针、6/8 上限和禁止递归。"
+      "expected_output": "允许 projectless；仍执行实体化健康探针、默认 6/8/3 或经扩容门的 12/16/6 上限，以及禁止递归。"
     },
     {
       "id": "durable-resume-no-duplicate",

--- a/skills/codex-model-routing-team/references/audit-schema.json
+++ b/skills/codex-model-routing-team/references/audit-schema.json
@@ -30,7 +30,7 @@
     "archived"
   ],
   "properties": {
-    "creation_attempt": {"type": "integer", "minimum": 1, "maximum": 8},
+    "creation_attempt": {"type": "integer", "minimum": 1, "maximum": 16},
     "subtask_attempt": {"type": "integer", "minimum": 1, "maximum": 2},
     "task_id": {"type": "string", "minLength": 1, "maxLength": 128},
     "thread_id": {"type": ["string", "null"]},

--- a/skills/codex-model-routing-team/references/model-registry.json
+++ b/skills/codex-model-routing-team/references/model-registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "2.1.0",
-  "updated_at": "2026-08-01",
+  "updated_at": "2026-08-04",
   "policy": {
     "runtime_metadata_role": "validate_only",
     "unknown_model_action": "reject",
@@ -11,19 +11,37 @@
     "speed_modes": ["standard", "fast"],
     "default_speed": "standard",
     "service_tier_by_speed": {"standard": null, "fast": "priority"},
-    "fast_routing_models": ["gpt-5.6-luna"],
+    "fast_routing_models": ["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"],
+    "default_fast_models": ["gpt-5.6-luna"],
     "app_thread_only_models": ["gpt-5.6-luna"],
     "native_first_candidate_requires_explicit_request": true,
     "default_surface": "app_thread",
     "default_openai_route": {
       "surface": "app_thread",
       "model": "gpt-5.6-luna",
-      "thinking": "xhigh"
+      "thinking": "xhigh",
+      "speed": "fast"
     },
     "high_risk_openai_route": {
       "surface": "app_thread",
       "model": "gpt-5.6-luna",
-      "thinking": "max"
+      "thinking": "max",
+      "speed": "fast"
+    },
+    "default_team_limit_profile": "standard",
+    "team_limit_profiles": {
+      "standard": {
+        "max_planned_workers": 6,
+        "max_worker_attempts": 8,
+        "max_new_workers_per_wave": 3,
+        "min_reserved_slots": 0
+      },
+      "expanded": {
+        "max_planned_workers": 12,
+        "max_worker_attempts": 16,
+        "max_new_workers_per_wave": 6,
+        "min_reserved_slots": 2
+      }
     },
     "minimum_thinking_by_model": {
       "gpt-5.6-luna": "xhigh",

--- a/skills/codex-model-routing-team/references/native-audit-schema.json
+++ b/skills/codex-model-routing-team/references/native-audit-schema.json
@@ -28,7 +28,7 @@
     "closed"
   ],
   "properties": {
-    "worker_attempt": {"type": "integer", "minimum": 1, "maximum": 8},
+    "worker_attempt": {"type": "integer", "minimum": 1, "maximum": 16},
     "subtask_attempt": {"type": "integer", "minimum": 1, "maximum": 2},
     "task_id": {"type": "string", "minLength": 1, "maxLength": 128},
     "surface": {"const": "native_subagent"},

--- a/skills/codex-model-routing-team/references/provider-policy.md
+++ b/skills/codex-model-routing-team/references/provider-policy.md
@@ -24,7 +24,7 @@
 
 ## OpenAI 基线
 
-`gpt-5.6-luna` 与 `gpt-5.6-sol` 使用当前 Codex App 已配置的 OpenAI 路径。自动路由默认创建 Luna XHigh App Thread，高难/高风险升 Luna Max；当前官方原生 V2 live schema 不开放 Luna。Sol 仅作为 High 以上的显式原生路径、fallback 或专项审查。只有 App Luna 可请求 Fast；Sol 与其他模型保持 Standard。当前项目若有更窄的数据规则，以项目规则为准。
+`gpt-5.6-luna` 与 `gpt-5.6-sol` 使用当前 Codex App 已配置的 OpenAI 路径。自动路由默认创建 Luna XHigh App Thread，高难/高风险升 Luna Max；当前官方原生 V2 live schema 不开放 Luna。Sol 仅作为 High 以上的显式原生路径、fallback 或专项审查。Luna 默认请求 Fast；Sol/Terra 默认 Standard，只有用户明确要求且 live Surface 接受 `service_tier=priority` 时才请求 Fast。当前项目若有更窄的数据规则，以项目规则为准。
 
 ## xAI / Grok 4.5
 

--- a/skills/codex-model-routing-team/references/recovery-policy.md
+++ b/skills/codex-model-routing-team/references/recovery-policy.md
@@ -48,7 +48,7 @@ App Thread 健康判断分为五层：
 
 成功缓存只参与候选排序，不保证下一次调用成功。建议在当前 run ledger 中对精确 `account-scope/host/surface/model/thinking/speed/tool-signature/App-version` 保存 10 分钟正向证据；不要为此创建新的全局状态事实源。
 
-原生 Subagent 使用更短的控制面：`PLANNED → SPAWN_PENDING → RUNNING → COMPLETED/FAILED → CLOSED`。它只用于显式请求或预声明 fallback，live spawn schema 必须接受精确 `model/reasoning_effort/speed`。当前 Luna 不在官方原生 V2 live schema 中；Sol 必须 High 以上并保持 Standard。V1 使用 `fork_context=false`，V2 使用 `fork_turns="none"`。返回 agent id 只证明 Worker 已创建；平台未回显实际模型或速度时，对应 observed 字段仍写 `unknown`。详见 [原生 Subagent 生命周期](native-subagent-lifecycle.md)。
+原生 Subagent 使用更短的控制面：`PLANNED → SPAWN_PENDING → RUNNING → COMPLETED/FAILED → CLOSED`。它只用于显式请求或预声明 fallback，live spawn schema 必须接受精确 `model/reasoning_effort/speed`。当前 Luna 不在官方原生 V2 live schema 中；Sol 必须 High 以上，默认 Standard，用户明确请求 Fast 时还必须有 `service_tier=priority` 的 tuple-bound live 证据。V1 使用 `fork_context=false`，V2 使用 `fork_turns="none"`。返回 agent id 只证明 Worker 已创建；平台未回显实际模型或速度时，对应 observed 字段仍写 `unknown`。详见 [原生 Subagent 生命周期](native-subagent-lifecycle.md)。
 
 ## 错误分类
 

--- a/skills/codex-model-routing-team/references/routing-policy.md
+++ b/skills/codex-model-routing-team/references/routing-policy.md
@@ -10,7 +10,7 @@
 - 任务跨调研、写作、编码、设计、测试或审查多个领域。
 - 预计节省的时间或质量增益明显高于协调成本。
 
-典型任务创建 2–3 个 Worker；广泛调研或多模块任务创建 4–6 个。简单问答、状态查询、单文件小改、强顺序流程直接由主 Agent 完成。
+典型任务创建 2–3 个 Worker；广泛调研或多模块任务通常创建 4–6 个。只有 7–12 个独立可验收产物能产生明确净收益、所有权隔离且 live host 容量允许时才使用 TeamPlan `expanded` 档。简单问答、状态查询、单文件小改、强顺序流程直接由主 Agent 完成。
 
 ## 选择顺序
 
@@ -31,16 +31,16 @@
 
 | 路由名 | Surface | `model` | 推理强度 | 速度 | 适用工作 |
 | --- | --- | --- | --- | --- | --- |
-| Native Sol High | `native_subagent` | `gpt-5.6-sol` | `high` | Standard | 用户明确要求原生或 App 不可用时的边界清晰 fallback |
-| Native Sol X High | `native_subagent` | `gpt-5.6-sol` | `xhigh` | Standard | 显式原生高难实现与审查 |
-| Native Sol Max | `native_subagent` | `gpt-5.6-sol` | `max` | Standard | 有明确质量理由的最高强度原生任务 |
+| Native Sol High | `native_subagent` | `gpt-5.6-sol` | `high` | Standard / 显式 Fast | 用户明确要求原生或 App 不可用时的边界清晰 fallback |
+| Native Sol X High | `native_subagent` | `gpt-5.6-sol` | `xhigh` | Standard / 显式 Fast | 显式原生高难实现与审查 |
+| Native Sol Max | `native_subagent` | `gpt-5.6-sol` | `max` | Standard / 显式 Fast | 有明确质量理由的最高强度原生任务 |
 | Luna X High App | `app_thread` | `gpt-5.6-luna` | `xhigh` | Standard / Fast | 默认 Worker；调研、写作、编码、验证与审查 |
 | Luna Max App | `app_thread` | `gpt-5.6-luna` | `max` | Standard / Fast | 高歧义、高风险或边界清晰的高难深度执行 |
-| Sol High | `app_thread` | `gpt-5.6-sol` | `high` | Standard | 高歧义规划、架构、困难调试、高风险判断、关键审查 |
-| Sol X High | `app_thread` | `gpt-5.6-sol` | `xhigh` | Standard | 更深推理的关键审查与方案裁决 |
-| Sol Max | `app_thread` | `gpt-5.6-sol` | `max` | Standard | 有明确质量理由的最高强度单任务 |
+| Sol High | `app_thread` | `gpt-5.6-sol` | `high` | Standard / 显式 Fast | 高歧义规划、架构、困难调试、高风险判断、关键审查 |
+| Sol X High | `app_thread` | `gpt-5.6-sol` | `xhigh` | Standard / 显式 Fast | 更深推理的关键审查与方案裁决 |
+| Sol Max | `app_thread` | `gpt-5.6-sol` | `max` | Standard / 显式 Fast | 有明确质量理由的最高强度单任务 |
 | Grok Medium/High | 任一已确认 Surface | `xai/grok-4.5` | `medium` / `high` | Standard | 条件自动的技术分析、Agent 执行与异构复核 |
-| Terra Opt-in | 任一已确认 Surface | `gpt-5.6-terra` | `low`–`max` | Standard | 用户明确点名且 live runtime 接受时的 opt-in Worker |
+| Terra Opt-in | 任一已确认 Surface | `gpt-5.6-terra` | `low`–`max` | Standard / 显式 Fast | 用户明确点名且 live runtime 接受时的 opt-in Worker |
 | Gemini Low/Medium/High | 任一已确认 Surface | `antigravity/gemini-3.6-flash` | `low` / `medium` / `high` | Standard | blocked manual-review 模板，当前不得创建 |
 
 `gpt-5.6-terra` 默认关闭，只能作为用户明确点名的首项候选，不能静默 fallback。Grok 必须通过 runtime/provider 预检。Gemini Antigravity 当前 `terms_default: blocked`；它出现在表中用于解释显式请求和未来迁移。
@@ -49,7 +49,7 @@ Ultra 永久禁止。不得把成本比例、订阅额度或 TPS 写成未经当
 
 `thinking` 是 RoutePlan 的跨 Surface 规范字段，比较顺序为 `low < medium < high < xhigh < max`。原生 spawn 时映射到 `reasoning_effort`；App Thread 创建时映射到 `thinking`。候选必须同时满足该 Surface 的支持范围和 `minimum_thinking`。Luna 自动路由只允许 XHigh/Max；Sol 无论 Surface 都只允许 High/XHigh/Max，Medium/Low 即使用户点名也拒绝。
 
-`speed` 是与模型、推理强度分离的 RoutePlan 字段，取值为 `standard | fast`。Fast 映射为 `service_tier=priority`；Standard 不传该 tier。只有 Luna 允许 `speed=fast`，Sol、Terra 和其他模型必须写 `speed=standard`。`schema_version: "2.1"` 的 RoutePlan 必须显式填写；旧计划省略版本/速度时兼容解释为 Standard。某个 Surface 的 live schema 没有速度参数时，该 Surface 不能证明或强制 Fast，必须把精确组合视为不可用或保持 Standard。
+`speed` 是与模型、推理强度分离的 RoutePlan 字段，取值为 `standard | fast`。Fast 映射为 `service_tier=priority`；Standard 不传该 tier。registry 的 `fast_routing_models` 表示候选资格，`default_fast_models` 表示默认偏好：Luna 默认 Fast，Sol/Terra 默认 Standard，只有用户明确要求时才允许后两者 Fast。`schema_version: "2.1"` 的 RoutePlan 必须显式填写；旧计划省略版本/速度时兼容解释为 Standard。任何 Surface 缺少 tuple-bound live 速度证据时都不能声称或强制 Fast，必须保持 Standard。
 
 ## 任务画像与候选链
 
@@ -59,8 +59,8 @@ Ultra 永久禁止。不得把成本比例、订阅额度或 TPS 写成未经当
 | --- | --- | --- | --- |
 | `NATIVE_WORKER_EXPLICIT` | high | Native Sol High → Luna X High App | 仅用户明确要求原生，或预声明 App 不可用 fallback |
 | `NATIVE_SMART_WORKER_EXPLICIT` | xhigh | Native Sol X High → Luna Max App | 显式原生高难任务；失败后回到 Luna App |
-| `DEFAULT_GENERAL` | high | Luna X High App → Sol High App Thread | 通用耐久研究、写作、编码与验证；App 未暴露速度参数时保持 Standard |
-| `HIGH_RISK_GENERAL` | xhigh | Luna Max App → Sol X High App Thread | 高风险、高歧义与高难执行默认升 Luna Max |
+| `DEFAULT_GENERAL` | high | Luna X High App Fast / Standard → Sol High App Thread | 通用耐久研究、写作、编码与验证；无 live Fast 证据时保持 Standard |
+| `HIGH_RISK_GENERAL` | xhigh | Luna Max App Fast / Standard → Sol X High App Thread | 高风险、高歧义与高难执行默认升 Luna Max |
 | `FAST_MECHANICAL` | xhigh | Luna X High App Fast / Standard → Sol High App | live create schema 接受 priority 才用 Fast，否则首项直接写 Standard |
 | `DEEP_AGENTIC_CODE` | high | Grok High → Sol High App Thread | Grok/provider 通过硬门后用于复杂工程执行 |
 | `REVIEW_OPENAI_PRIMARY` | high | Grok High → Sol X High App Thread | OpenAI 主执行后的异构复核 |
@@ -93,7 +93,7 @@ fallback 必须满足最低 `thinking`。首项被静态门排除时，通知应
 }
 ```
 
-当前官方原生 V2 live schema 不开放 Luna，因此不得生成 Native Luna 候选。App Luna Fast 只有在 `create_thread` 的 live schema 明确接受速度参数时才允许，并在候选中附加：
+当前官方原生 V2 live schema 不开放 Luna，因此不得生成 Native Luna 候选。任何 App Fast 只有在 `create_thread` 的 live schema 明确接受速度参数时才允许；以下为默认 Luna 候选证据：
 
 ```json
 "speed_evidence": {
@@ -121,8 +121,8 @@ python3 scripts/validate_route_plan.py /path/to/route-plan.json
 
 ## 数量与失败升级
 
-- 跨 Surface 运行并发上限 6；root `worker_attempt` 上限 8，替换、超时歧义、未实体化和原生 spawn 失败都计数。
-- `planned_workers + reserved_slots <= 8`。reserved slots 用于上游后续阶段和失败恢复。
+- TeamPlan `standard` 档并发 6、root attempts 8、每波 3；`expanded` 档上限 12/16/6。替换、超时歧义、未实体化和原生 spawn 失败都计数，live host 更窄上限优先。
+- `planned_workers + reserved_slots` 不得超过所选档位的 attempt cap；expanded 至少保留 2 个 reserved slots，用于失败恢复。
 - Deep Research 默认预算为 `2-4 researcher + 1 verifier + 1 reviewer + 2 retry reserve`；verifier → reviewer 的阶段依赖必须保持串行。
 - 完整输出质量不足时，原 Worker 最多一次 follow-up；仍失败才进入候选链下一项。
 - 同一子任务最多两个 Worker attempt；单候选失败后由主 Agent 接管。

--- a/skills/codex-model-routing-team/references/surface-selection-policy.md
+++ b/skills/codex-model-routing-team/references/surface-selection-policy.md
@@ -5,7 +5,7 @@
 ## 确定性选择顺序
 
 1. 简单问答、状态查询、单文件小改、强顺序任务和不可逆操作留在主 Agent。
-2. 自动路由默认 `app_thread`，优先使用 `gpt-5.6-luna/xhigh`；高难或高风险任务使用 Luna Max。短时和文件数量不改变这个默认值。
+2. 自动路由默认 `app_thread`，优先使用 `gpt-5.6-luna/xhigh/fast`；高难或高风险任务使用 Luna Max Fast。当前 Surface 无 Fast live 证据时改写为 Standard。短时和文件数量不改变模型默认值。
 3. 只有用户明确要求原生 Subagent，或 App Thread 路径不可用且 RoutePlan 已预声明 fallback 时，才使用 `native_subagent`。当前官方原生 V2 live schema 不开放 Luna；原生 OpenAI 自动候选只能使用 live schema 接受的 Sol High/XHigh/Max，Terra 仍须用户点名。
 4. Surface 缺少精确 live 能力、Provider 门不通过或所有权无法隔离时，进入预声明的下一候选；没有下一候选时由主 Agent 接管。
 
@@ -15,13 +15,13 @@
 {"surface": "app_thread", "model": "gpt-5.6-luna", "thinking": "xhigh", "speed": "standard"}
 ```
 
-`thinking` 是策略字段：原生工具映射为 `reasoning_effort`，App Thread 映射为 `thinking`。Luna 最低 XHigh，Sol 最低 High。`speed=fast` 映射为 `service_tier=priority`，只有 App Luna 可以使用，且必须有 live Surface 证据。跨 Surface fallback 必须在 `candidates` 中预声明；`surface + model + thinking + speed` 才是唯一组合。
+`thinking` 是策略字段：原生工具映射为 `reasoning_effort`，App Thread 映射为 `thinking`。Luna 最低 XHigh，Sol 最低 High。`speed=fast` 映射为 `service_tier=priority`；Luna 默认 Fast，Sol/Terra 默认 Standard，后两者只有用户明确要求时才候选 Fast。所有 Fast 都必须有 live Surface 证据。跨 Surface fallback 必须在 `candidates` 中预声明；`surface + model + thinking + speed` 才是唯一组合。
 
 ## 额度
 
 - 一个子任务最多两个候选，`max_worker_threads` 等于候选数。
 - 任何已开始的 `spawn_agent` 或 `create_thread` 都消耗一次 root Worker attempt；静态门排除不消耗。
-- 跨 Surface 总并发最多 6，root Worker attempts 最多 8。
+- 默认 `standard` 档跨 Surface 并发 6、root attempts 8、每波 3；有扩容理由、隔离所有权和至少 2 个 reserved slots 的 `expanded` 档上限为 12/16/6。实际 host 更窄时以 live 上限为准。
 - 原生 V2 没有 live 上限证据时按“协调者 + 3 个 child”执行；任何更窄 host 上限优先。
 - Worker 永不使用 Ultra，永不继续派生 Agent、Thread 或后台任务。
 

--- a/skills/codex-model-routing-team/references/team-plan.md
+++ b/skills/codex-model-routing-team/references/team-plan.md
@@ -24,6 +24,7 @@
   "planning_source": "ad_hoc",
   "source_refs": [],
   "root_goal": "交付完整且经主 Agent 验证的结果",
+  "scale_profile": "standard",
   "units": [
     {
       "unit_id": "U1",
@@ -72,10 +73,11 @@ printf '%s' "$TEAM_PLAN_JSON" | python3 scripts/validate_team_plan.py -
 
 ## 调度与所有权
 
-- 依赖图是唯一调度事实源；validator 计算就绪层并按每波最多 3 个切分。
+- 依赖图是唯一调度事实源；validator 按所选档位计算并切分就绪层。
 - 同一就绪层出现相同或父子写入路径时拒绝，主 Agent 必须增加依赖、串行化或重分所有权。
 - 文件不重叠不等于语义独立；共享 API、schema、migration、lockfile、生成物、服务、数据库、浏览器会话和限流仍由主 Agent 判断。
-- `planned workers + reserved_slots <= 8`；Worker 单元最多 6 个，跨 Surface 并发仍最多 6。
+- `standard` 是默认档：最多 6 个 Worker、累计 8 次 attempts、每波 3 个。
+- 只有大量独立可验收产物带来明确净收益、写入完全隔离且 live host 容量允许时，主 Agent 才写 `scale_profile: "expanded"` 和具体 `scale_reason`：最多 12 个 Worker、累计 16 次 attempts、每波 6 个，并至少保留 2 个 `reserved_slots`。更窄的 host/runtime 上限优先，禁止把策略上限当成平台保证。
 - `integration_order` 必须覆盖全部单元并尊重依赖；`integration_owner` 固定为 `lead`。
 
 验证通过后，每个 unit 恰好生成一份 Task Packet 和一份 RoutePlan。派遣简报只展示 Worker 数、精确路由和职责，不向用户倾倒 TeamPlan JSON。

--- a/skills/codex-model-routing-team/references/thread-lifecycle.md
+++ b/skills/codex-model-routing-team/references/thread-lifecycle.md
@@ -67,7 +67,7 @@ python3 scripts/validate_route_plan.py /path/to/route-plan.json
 3. 返回 `threadId`、`pendingWorktreeId`、超时或未知形状时，严格按 `thread-supervision-protocol.md` 分类和恢复。
 4. `pendingWorktreeId` 不是正式 Thread id；只有唯一 task id 查询、正式读取和稳定观察通过后才进入 `CONTROL_READY`。
 5. 当前 turn 出现首个 assistant-originated reasoning/message 或模型工具调用时进入 `DATA_READY`。user message、Thread 元数据、客户端提示和 MCP 初始化错误不计入。
-6. 同组合探针通过后每波最多新增 3 个任务，防止新会话同时初始化 MCP 造成拥塞。
+6. 同组合探针通过后按 TeamPlan 档位新增任务：`standard` 每波最多 3 个，具备扩容理由且 live host 容量允许的 `expanded` 每波最多 6 个，防止新会话同时初始化 MCP 造成拥塞。
 
 `DATA_READY` 与模型/速度身份分开；没有真实回显时，`observed_runtime_model` 与 `observed_runtime_speed` 保持 `unknown`。
 

--- a/skills/codex-model-routing-team/references/upstream-skill-adapter.md
+++ b/skills/codex-model-routing-team/references/upstream-skill-adapter.md
@@ -19,7 +19,7 @@
 - RoutePlan、Provider allowlist、模型预检与 deterministic fallback
 - 原生 Subagent 的 fresh-context spawn、等待、follow-up 与关闭
 - App Thread 的 project / projectless 选择、创建、实体化、读取、追问与归档
-- 跨 Surface 并发 6、worker attempts 8、reserved slots 与升级次数
+- TeamPlan 默认 6/8/3，或经扩容理由、所有权隔离和 live host 容量门启用 12/16/6；同时保留 reserved slots 与升级次数
 - 单写者和禁止下级派遣等安全边界
 
 遇到冲突时，上游业务流程优先，路由安全上限保持强制。预算不足时收敛 Worker 数量并报告，禁止跳过上游验证阶段。
@@ -42,7 +42,7 @@
 ## Deep Research 预设
 
 ```text
-researcher_count + 1 verifier + 1 reviewer + retry_reserve <= 8
+standard: researcher_count + 1 verifier + 1 reviewer + retry_reserve <= 8
 ```
 
 - researcher：默认 2–4 个，使用 Luna X High App；高难主题升 Luna Max。live create schema 接受 priority 时可用 Fast，否则保持 Standard。公开技术研究可在 Provider 门通过后使用 Grok Medium。

--- a/skills/codex-model-routing-team/references/validation-cases.md
+++ b/skills/codex-model-routing-team/references/validation-cases.md
@@ -44,7 +44,7 @@ Prompt：CE Plan 已定义 U1/U2、Dependencies、Files 和 Verification，请�
 
 Prompt：使用 Grok 4.5 实现复杂模块，再让另一个模型独立审查，最后由主 Agent 集成。
 
-应出现：`DEEP_AGENTIC_CODE`；Grok High → Sol High 的固定候选链；不同 provider 的审查；单写者；6/8 上限；主 Agent 最终验收。
+应出现：`DEEP_AGENTIC_CODE`；Grok High → Sol High 的固定候选链；不同 provider 的审查；单写者；默认 6/8/3，满足扩容门时可用 12/16/6；主 Agent 最终验收。
 
 ### Native exact-model happy path
 
@@ -76,17 +76,23 @@ Prompt：创建 Luna XHigh App Thread，当前 `create_thread` schema 只有 mod
 
 应出现：App 路由保持 Standard；不得声称 Fast。若 RoutePlan 强制 App Fast，则因缺少 `speed_evidence` 被拒绝。
 
-### Sol Fast regression
+### Sol Fast requires explicit request
 
 Prompt：使用 Sol XHigh 并打开 Fast。
 
-应出现：RoutePlan 被静态拒绝；Sol 只允许 Standard，Fast 只允许 Luna。
+应出现：自动 RoutePlan 被静态拒绝；Sol 默认 Standard。只有用户明确要求且 live schema 接受 `service_tier=priority` 时，精确 Sol Fast 候选才通过。
 
 ### Four short outputs stay lightweight
 
 Prompt：四个互斥的小文件预计十分钟完成，明确交给三个 Sol High 原生 Worker，结果回到父任务集成，不需要恢复或独立历史。
 
-应出现：因用户明确点名原生而选择 `native-light`；不创建持久协调文件；Provider、Sol High 下限、6/8、单写者、fresh-context、身份和关闭门保持不变。
+应出现：因用户明确点名原生而选择 `native-light`；不创建持久协调文件；Provider、Sol High 下限、默认 6/8/3、单写者、fresh-context、身份和关闭门保持不变。
+
+### Expanded TeamPlan
+
+Prompt：12 个互不依赖的审核对象，各自产出独立报告，主 Agent 统一汇总；live host 可承载 6 个并发 Worker。
+
+应出现：主 Agent 记录明确 `scale_reason`，验证所有权无重叠，使用 `expanded` 12/16/6 并保留至少 2 个 reserved slots；若 live host 更窄则降低每波数量。
 
 ### Native model rejection
 

--- a/skills/codex-model-routing-team/scripts/model_preflight.py
+++ b/skills/codex-model-routing-team/scripts/model_preflight.py
@@ -295,6 +295,9 @@ def main() -> int:
     fast_routing_models = set(
         registry.get("policy", {}).get("fast_routing_models", [])
     )
+    default_fast_models = set(
+        registry.get("policy", {}).get("default_fast_models", [])
+    )
     app_thread_only_models = set(
         registry.get("policy", {}).get("app_thread_only_models", [])
     )
@@ -306,7 +309,15 @@ def main() -> int:
     elif args.thinking not in registry_thinking:
         result["errors"].append("thinking is not declared for this model")
     if args.speed == "fast" and args.model not in fast_routing_models:
-        result["errors"].append("Fast is outside the Luna-only routing policy")
+        result["errors"].append("Fast is not eligible for this model in registry policy")
+    if (
+        args.speed == "fast"
+        and args.model not in default_fast_models
+        and not args.explicit_user_request
+    ):
+        result["errors"].append(
+            "non-default Fast requires an explicit user request"
+        )
     if args.service_tier_confirmed and args.speed != "fast":
         result["errors"].append("--service-tier-confirmed requires --speed fast")
     if args.service_tier_confirmed and not args.runtime_confirmed:
@@ -325,6 +336,7 @@ def main() -> int:
         "thinking_supported": args.thinking in registry_thinking,
         "speed": args.speed,
         "fast_policy_allowed": args.model in fast_routing_models,
+        "fast_by_default": args.model in default_fast_models,
     }
 
     if entry.get("terms_default") == "blocked":

--- a/skills/codex-model-routing-team/scripts/validate_route_plan.py
+++ b/skills/codex-model-routing-team/scripts/validate_route_plan.py
@@ -155,6 +155,9 @@ def main() -> int:
     speed_modes = set(registry.get("policy", {}).get("speed_modes", []))
     default_speed = registry.get("policy", {}).get("default_speed", "standard")
     fast_routing_models = set(registry.get("policy", {}).get("fast_routing_models", []))
+    default_fast_models = set(
+        registry.get("policy", {}).get("default_fast_models", [])
+    )
     app_thread_only_models = set(
         registry.get("policy", {}).get("app_thread_only_models", [])
     )
@@ -226,7 +229,17 @@ def main() -> int:
             result["errors"].append(f"candidate {index} uses an unknown speed")
             continue
         if speed == "fast" and model_id not in fast_routing_models:
-            result["errors"].append(f"candidate {index} requests Fast outside the Luna-only routing policy")
+            result["errors"].append(
+                f"candidate {index} requests Fast for a registry-ineligible model"
+            )
+        if (
+            speed == "fast"
+            and model_id not in default_fast_models
+            and plan.get("explicit_user_request") is not True
+        ):
+            result["errors"].append(
+                f"candidate {index} non-default Fast requires explicit_user_request"
+            )
         if surface == "native_subagent" and model_id in app_thread_only_models:
             result["errors"].append(
                 f"candidate {index} model is App Thread only in the current routing policy"

--- a/skills/codex-model-routing-team/scripts/validate_team_ledger.py
+++ b/skills/codex-model-routing-team/scripts/validate_team_ledger.py
@@ -14,8 +14,9 @@ from validate_team_plan import validate_team_plan_payload
 SKILL_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_SCHEMA = SKILL_ROOT / "references" / "audit-schema.json"
 DEFAULT_NATIVE_SCHEMA = SKILL_ROOT / "references" / "native-audit-schema.json"
-MAX_CREATION_ATTEMPTS = 8
-MAX_IN_FLIGHT = 6
+DEFAULT_REGISTRY = SKILL_ROOT / "references" / "model-registry.json"
+FALLBACK_MAX_CREATION_ATTEMPTS = 8
+FALLBACK_MAX_IN_FLIGHT = 6
 CURRENT_ROUTE_PLAN_SCHEMA_VERSION = "2.1"
 SPEED_MODES = {"standard", "fast"}
 
@@ -37,6 +38,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("ledger", help="ledger JSON path, or - to read JSON from stdin")
     parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
     parser.add_argument("--native-schema", type=Path, default=DEFAULT_NATIVE_SCHEMA)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
     return parser.parse_args()
 
 
@@ -89,6 +91,8 @@ def validate_speed_identity(
     *,
     prefix: str,
     accepted_states: set[str],
+    fast_routing_models: set[str],
+    default_fast_models: set[str],
     errors: list[str],
 ) -> None:
     route_plan = record.get("route_plan")
@@ -124,8 +128,18 @@ def validate_speed_identity(
     if requested not in SPEED_MODES:
         errors.append(f"{prefix} has invalid requested_speed")
         return
-    if requested == "fast" and record.get("requested_model") != "gpt-5.6-luna":
-        errors.append(f"{prefix} requests Fast outside the Luna-only routing policy")
+    requested_model = record.get("requested_model")
+    if requested == "fast" and requested_model not in fast_routing_models:
+        errors.append(f"{prefix} requests Fast for a registry-ineligible model")
+    if (
+        requested == "fast"
+        and requested_model not in default_fast_models
+        and not (
+            isinstance(route_plan, dict)
+            and route_plan.get("explicit_user_request") is True
+        )
+    ):
+        errors.append(f"{prefix} non-default Fast lacks explicit_user_request")
     if accepted is not None and accepted not in SPEED_MODES:
         errors.append(f"{prefix} has invalid platform_accepted_speed")
     if observed not in {None, "unknown", *SPEED_MODES}:
@@ -161,19 +175,55 @@ def main() -> int:
         "ledger_valid": False,
         "record_count": 0,
         "in_flight_count": 0,
+        "scale_profile": "standard",
+        "limits": {},
         "errors": [],
         "warnings": [],
     }
     try:
         payload = load_input(args.ledger)
         root, records = records_from(payload)
+        registry = load_json(args.registry)
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         result["errors"].append(f"JSON load failed: {exc}")
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return 2
 
+    policy = registry.get("policy", {}) if isinstance(registry, dict) else {}
+    default_profile = policy.get("default_team_limit_profile", "standard")
+    profiles = policy.get("team_limit_profiles", {})
+    default_limits = (
+        profiles.get(default_profile, {}) if isinstance(profiles, dict) else {}
+    )
+    max_creation_attempts = default_limits.get(
+        "max_worker_attempts", FALLBACK_MAX_CREATION_ATTEMPTS
+    )
+    max_in_flight = default_limits.get(
+        "max_planned_workers", FALLBACK_MAX_IN_FLIGHT
+    )
+    if (
+        not isinstance(max_creation_attempts, int)
+        or isinstance(max_creation_attempts, bool)
+        or max_creation_attempts < 1
+    ):
+        max_creation_attempts = FALLBACK_MAX_CREATION_ATTEMPTS
+    if (
+        not isinstance(max_in_flight, int)
+        or isinstance(max_in_flight, bool)
+        or max_in_flight < 1
+    ):
+        max_in_flight = FALLBACK_MAX_IN_FLIGHT
+    fast_routing_models = set(policy.get("fast_routing_models", []))
+    default_fast_models = set(policy.get("default_fast_models", []))
+    result["scale_profile"] = default_profile
+    result["limits"] = {
+        "max_worker_attempts": max_creation_attempts,
+        "max_planned_workers": max_in_flight,
+    }
     result["record_count"] = len(records)
     team_plan_units: dict[int, set[str]] = {}
+    team_plan_limits: dict[int, dict[str, int]] = {}
+    team_plan_profiles: dict[int, str] = {}
     active_team_plan_revision: int | None = None
     if root is not None and (
         "team_plans" in root or "active_team_plan_revision" in root
@@ -185,7 +235,7 @@ def main() -> int:
         else:
             revisions: list[int] = []
             for index, team_plan in enumerate(team_plans):
-                validation = validate_team_plan_payload(team_plan)
+                validation = validate_team_plan_payload(team_plan, registry)
                 if not validation["team_plan_valid"]:
                     for error in validation["errors"]:
                         result["errors"].append(
@@ -197,6 +247,8 @@ def main() -> int:
                 team_plan_units[revision] = {
                     unit["unit_id"] for unit in team_plan["units"]
                 }
+                team_plan_limits[revision] = validation["limits"]
+                team_plan_profiles[revision] = validation["scale_profile"]
             if revisions and revisions != list(range(1, len(revisions) + 1)):
                 result["errors"].append(
                     "TeamPlan revisions must be ordered and contiguous from 1"
@@ -213,6 +265,12 @@ def main() -> int:
                 result["errors"].append(
                     "active_team_plan_revision must name the latest revision"
                 )
+            elif active_team_plan_revision in team_plan_limits:
+                active_limits = team_plan_limits[active_team_plan_revision]
+                max_creation_attempts = active_limits["max_worker_attempts"]
+                max_in_flight = active_limits["max_planned_workers"]
+                result["scale_profile"] = team_plan_profiles[active_team_plan_revision]
+                result["limits"] = active_limits
     surfaces = {
         record.get("surface", "app_thread")
         for record in records
@@ -243,7 +301,7 @@ def main() -> int:
         .get("enum", [])
     )
 
-    if len(records) > MAX_CREATION_ATTEMPTS:
+    if len(records) > max_creation_attempts:
         result["errors"].append("worker records exceed the root worker-attempt cap")
 
     attempts: list[int] = []
@@ -316,7 +374,7 @@ def main() -> int:
             if (
                 not isinstance(attempt, int)
                 or isinstance(attempt, bool)
-                or not 1 <= attempt <= MAX_CREATION_ATTEMPTS
+                or not 1 <= attempt <= max_creation_attempts
             ):
                 result["errors"].append(f"{prefix} has invalid worker_attempt")
             else:
@@ -397,6 +455,8 @@ def main() -> int:
                 record,
                 prefix=prefix,
                 accepted_states={"RUNNING", "COMPLETED", "CLOSED"},
+                fast_routing_models=fast_routing_models,
+                default_fast_models=default_fast_models,
                 errors=result["errors"],
             )
 
@@ -445,7 +505,11 @@ def main() -> int:
             result["errors"].append(f"{prefix} is missing required fields: {', '.join(missing)}")
 
         attempt = record.get("creation_attempt")
-        if not isinstance(attempt, int) or isinstance(attempt, bool) or not 1 <= attempt <= 8:
+        if (
+            not isinstance(attempt, int)
+            or isinstance(attempt, bool)
+            or not 1 <= attempt <= max_creation_attempts
+        ):
             result["errors"].append(f"{prefix} has invalid creation_attempt")
         else:
             attempts.append(attempt)
@@ -454,7 +518,7 @@ def main() -> int:
             if (
                 not isinstance(worker_attempt, int)
                 or isinstance(worker_attempt, bool)
-                or not 1 <= worker_attempt <= MAX_CREATION_ATTEMPTS
+                or not 1 <= worker_attempt <= max_creation_attempts
             ):
                 result["errors"].append(f"{prefix} has invalid worker_attempt")
             elif worker_attempt != attempt:
@@ -561,6 +625,8 @@ def main() -> int:
             record,
             prefix=prefix,
             accepted_states={"CONTROL_READY", "DATA_READY", "COMPLETED"},
+            fast_routing_models=fast_routing_models,
+            default_fast_models=default_fast_models,
             errors=result["errors"],
         )
 
@@ -604,7 +670,7 @@ def main() -> int:
         result["errors"].append("Worker attempt values must be unique")
     if attempts and sorted(attempts) != list(range(1, len(attempts) + 1)):
         result["errors"].append("Worker attempt values must be contiguous from 1")
-    if result["in_flight_count"] > MAX_IN_FLIGHT:
+    if result["in_flight_count"] > max_in_flight:
         result["errors"].append("in-flight records exceed the concurrency cap")
 
     if active_team_plan_revision is not None:

--- a/skills/codex-model-routing-team/scripts/validate_team_plan.py
+++ b/skills/codex-model-routing-team/scripts/validate_team_plan.py
@@ -10,9 +10,14 @@ from typing import Any
 
 
 CURRENT_SCHEMA_VERSION = "1.0"
-MAX_PLANNED_WORKERS = 6
-MAX_WORKER_ATTEMPTS = 8
-MAX_NEW_WORKERS_PER_WAVE = 3
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REGISTRY = SKILL_ROOT / "references" / "model-registry.json"
+FALLBACK_LIMIT_PROFILE = {
+    "max_planned_workers": 6,
+    "max_worker_attempts": 8,
+    "max_new_workers_per_wave": 3,
+    "min_reserved_slots": 0,
+}
 PLANNING_SOURCES = {"ad_hoc", "codex_plan", "ce_plan", "upstream_skill"}
 ROLES = {"researcher", "implementer", "verifier", "reviewer", "custom"}
 UNIT_ID_PATTERN = re.compile(r"^U[1-9][0-9]*$")
@@ -23,6 +28,10 @@ def load_input(source: str) -> Any:
     if source == "-":
         return json.load(sys.stdin)
     return json.loads(Path(source).read_text(encoding="utf-8"))
+
+
+def load_registry(path: Path = DEFAULT_REGISTRY) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def nonempty_string(value: Any) -> bool:
@@ -57,13 +66,17 @@ def paths_overlap(left: str, right: str) -> bool:
     return left_parts[:shorter] == right_parts[:shorter]
 
 
-def validate_team_plan_payload(payload: Any) -> dict[str, Any]:
+def validate_team_plan_payload(
+    payload: Any, registry: dict[str, Any] | None = None
+) -> dict[str, Any]:
     result: dict[str, Any] = {
         "status": "fail",
         "team_plan_valid": False,
         "schema_version": None,
         "revision": None,
         "worker_count": 0,
+        "scale_profile": None,
+        "limits": {},
         "dispatch_waves": [],
         "errors": [],
         "warnings": [],
@@ -73,6 +86,42 @@ def validate_team_plan_payload(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, dict):
         errors.append("TeamPlan must be a JSON object")
         return result
+
+    if registry is None:
+        try:
+            loaded_registry = load_registry()
+        except (OSError, json.JSONDecodeError):
+            loaded_registry = {}
+        registry = loaded_registry if isinstance(loaded_registry, dict) else {}
+    policy = registry.get("policy", {}) if isinstance(registry, dict) else {}
+    profiles = policy.get("team_limit_profiles", {})
+    default_profile = policy.get("default_team_limit_profile", "standard")
+    scale_profile = payload.get("scale_profile", default_profile)
+    result["scale_profile"] = scale_profile
+    limits = profiles.get(scale_profile) if isinstance(profiles, dict) else None
+    if not isinstance(limits, dict):
+        if scale_profile == "standard":
+            limits = dict(FALLBACK_LIMIT_PROFILE)
+        else:
+            errors.append("scale_profile is not declared in registry policy")
+            limits = dict(FALLBACK_LIMIT_PROFILE)
+    required_limits = (
+        "max_planned_workers",
+        "max_worker_attempts",
+        "max_new_workers_per_wave",
+        "min_reserved_slots",
+    )
+    if not (
+        all(valid_int(limits.get(field), minimum=1) for field in required_limits[:3])
+        and valid_int(limits.get("min_reserved_slots"))
+    ):
+        errors.append("scale_profile limits are invalid")
+        limits = dict(FALLBACK_LIMIT_PROFILE)
+    result["limits"] = {field: limits[field] for field in required_limits}
+    if scale_profile != default_profile and not nonempty_string(
+        payload.get("scale_reason")
+    ):
+        errors.append("non-default scale_profile requires scale_reason")
 
     schema_version = payload.get("schema_version")
     revision = payload.get("revision")
@@ -114,14 +163,25 @@ def validate_team_plan_payload(payload: Any) -> dict[str, Any]:
         errors.append("units must be an array")
         return result
     result["worker_count"] = len(units)
-    if not 2 <= len(units) <= MAX_PLANNED_WORKERS:
-        errors.append("TeamPlan must contain between 2 and 6 Worker units")
+    max_planned_workers = limits["max_planned_workers"]
+    max_worker_attempts = limits["max_worker_attempts"]
+    max_new_workers_per_wave = limits["max_new_workers_per_wave"]
+    min_reserved_slots = limits["min_reserved_slots"]
+    if not 2 <= len(units) <= max_planned_workers:
+        errors.append(
+            f"TeamPlan must contain between 2 and {max_planned_workers} Worker units"
+        )
 
     reserved_slots = payload.get("reserved_slots")
     if not valid_int(reserved_slots):
         errors.append("reserved_slots must be a non-negative integer")
-    elif len(units) + reserved_slots > MAX_WORKER_ATTEMPTS:
-        errors.append("planned Workers plus reserved_slots exceed the attempt cap")
+    else:
+        if reserved_slots < min_reserved_slots:
+            errors.append(
+                f"scale_profile requires at least {min_reserved_slots} reserved_slots"
+            )
+        if len(units) + reserved_slots > max_worker_attempts:
+            errors.append("planned Workers plus reserved_slots exceed the attempt cap")
 
     unit_order: list[str] = []
     units_by_id: dict[str, dict[str, Any]] = {}
@@ -221,9 +281,9 @@ def validate_team_plan_payload(payload: Any) -> dict[str, Any]:
                                 errors.append(
                                     f"ready units {left_id} and {right_id} have overlapping write scope"
                                 )
-            for start in range(0, len(layer), MAX_NEW_WORKERS_PER_WAVE):
+            for start in range(0, len(layer), max_new_workers_per_wave):
                 result["dispatch_waves"].append(
-                    layer[start : start + MAX_NEW_WORKERS_PER_WAVE]
+                    layer[start : start + max_new_workers_per_wave]
                 )
 
         integration_order = payload.get("integration_order")
@@ -253,6 +313,7 @@ def parse_args() -> argparse.Namespace:
         description="Validate a lightweight TeamPlan before multi-Worker dispatch."
     )
     parser.add_argument("plan", help="TeamPlan JSON path, or - to read JSON from stdin")
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
     return parser.parse_args()
 
 
@@ -260,6 +321,7 @@ def main() -> int:
     args = parse_args()
     try:
         payload = load_input(args.plan)
+        registry = load_registry(args.registry)
     except (OSError, json.JSONDecodeError) as exc:
         result = {
             "status": "fail",
@@ -269,7 +331,7 @@ def main() -> int:
         }
         print(json.dumps(result, ensure_ascii=False, indent=2))
         return 2
-    result = validate_team_plan_payload(payload)
+    result = validate_team_plan_payload(payload, registry)
     print(json.dumps(result, ensure_ascii=False, indent=2))
     return 0 if result["team_plan_valid"] else 2
 

--- a/tests/skills/codex-model-routing-team-expected.json
+++ b/tests/skills/codex-model-routing-team-expected.json
@@ -12,6 +12,9 @@
   "max_concurrent_workers": 6,
   "max_total_workers": 8,
   "max_new_threads_per_wave_after_probe": 3,
+  "expanded_max_concurrent_workers": 12,
+  "expanded_max_total_workers": 16,
+  "expanded_max_new_workers_per_wave": 6,
   "forbidden_worker_thinking": ["ultra"],
   "required_thread_audit_fields": [
     "creation_attempt",

--- a/tests/skills/test_codex_model_routing_team.py
+++ b/tests/skills/test_codex_model_routing_team.py
@@ -52,7 +52,11 @@ class SkillContractTests(unittest.TestCase):
         models = {item["id"]: item for item in registry["models"]}
         self.assertTrue(models["gpt-5.6-luna"]["automatic"])
         self.assertTrue(models["gpt-5.6-sol"]["automatic"])
-        self.assertEqual(registry["policy"]["fast_routing_models"], ["gpt-5.6-luna"])
+        self.assertEqual(
+            registry["policy"]["fast_routing_models"],
+            ["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"],
+        )
+        self.assertEqual(registry["policy"]["default_fast_models"], ["gpt-5.6-luna"])
         self.assertEqual(registry["policy"]["app_thread_only_models"], ["gpt-5.6-luna"])
         self.assertEqual(registry["policy"]["default_surface"], "app_thread")
         self.assertEqual(
@@ -61,6 +65,16 @@ class SkillContractTests(unittest.TestCase):
                 "surface": "app_thread",
                 "model": "gpt-5.6-luna",
                 "thinking": "xhigh",
+                "speed": "fast",
+            },
+        )
+        self.assertEqual(
+            registry["policy"]["team_limit_profiles"]["expanded"],
+            {
+                "max_planned_workers": 12,
+                "max_worker_attempts": 16,
+                "max_new_workers_per_wave": 6,
+                "min_reserved_slots": 2,
             },
         )
         self.assertEqual(models["gpt-5.6-luna"]["surface_thinking"]["native_subagent"], [])
@@ -147,6 +161,7 @@ class SkillContractTests(unittest.TestCase):
             "Regression",
             "Net-positive TeamPlan",
             "TeamPlan write collision",
+            "Expanded TeamPlan",
         ):
             self.assertIn(case, cases)
 
@@ -183,6 +198,8 @@ class SkillContractTests(unittest.TestCase):
         unit_count: int = 2,
         revision: int = 1,
         supersedes_revision: int | None = None,
+        scale_profile: str | None = None,
+        scale_reason: str | None = None,
     ) -> dict[str, object]:
         units = []
         for index in range(1, unit_count + 1):
@@ -200,7 +217,7 @@ class SkillContractTests(unittest.TestCase):
                     "done_when": f"Unit {index} evidence is reviewable",
                 }
             )
-        return {
+        plan: dict[str, object] = {
             "schema_version": "1.0",
             "revision": revision,
             "supersedes_revision": supersedes_revision,
@@ -214,6 +231,11 @@ class SkillContractTests(unittest.TestCase):
             "final_verification": "Lead verifies the integrated result",
             "revision_reason": "initial" if revision == 1 else "new dependency evidence",
         }
+        if scale_profile is not None:
+            plan["scale_profile"] = scale_profile
+        if scale_reason is not None:
+            plan["scale_reason"] = scale_reason
+        return plan
 
     def test_team_plan_validator_accepts_stdin_and_computes_waves(self) -> None:
         plan = self.team_plan(unit_count=4)
@@ -265,6 +287,45 @@ class SkillContractTests(unittest.TestCase):
         result = self.run_team_plan_validator(plan)
         self.assertEqual(result.returncode, 2, result.stdout)
         self.assertIn("requires source_refs", result.stdout)
+
+    def test_team_plan_validator_uses_expanded_profile_only_with_reason_and_reserve(self) -> None:
+        standard = self.team_plan(unit_count=7)
+        standard["reserved_slots"] = 1
+        rejected = self.run_team_plan_validator(standard)
+        self.assertEqual(rejected.returncode, 2, rejected.stdout)
+        self.assertIn("between 2 and 6", rejected.stdout)
+
+        expanded = self.team_plan(
+            unit_count=12,
+            scale_profile="expanded",
+            scale_reason="Twelve independent read-only reviews have isolated outputs.",
+        )
+        expanded["reserved_slots"] = 2
+        accepted = self.run_team_plan_validator(expanded)
+        self.assertEqual(accepted.returncode, 0, accepted.stdout)
+        payload = json.loads(accepted.stdout)
+        self.assertEqual(payload["scale_profile"], "expanded")
+        self.assertEqual(payload["dispatch_waves"], [
+            ["U1", "U2", "U3", "U4", "U5", "U6"],
+            ["U7", "U8", "U9", "U10", "U11", "U12"],
+        ])
+
+        expanded.pop("scale_reason")
+        expanded["reserved_slots"] = 1
+        invalid = self.run_team_plan_validator(expanded)
+        self.assertEqual(invalid.returncode, 2, invalid.stdout)
+        self.assertIn("requires scale_reason", invalid.stdout)
+        self.assertIn("at least 2 reserved_slots", invalid.stdout)
+
+        too_large = self.team_plan(
+            unit_count=13,
+            scale_profile="expanded",
+            scale_reason="Independent outputs still remain policy-bounded.",
+        )
+        too_large["reserved_slots"] = 2
+        oversized = self.run_team_plan_validator(too_large)
+        self.assertEqual(oversized.returncode, 2, oversized.stdout)
+        self.assertIn("between 2 and 12", oversized.stdout)
 
     def run_preflight(self, *args: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
@@ -425,7 +486,31 @@ class SkillContractTests(unittest.TestCase):
         self.assertEqual(terra_explicit.returncode, 0, terra_explicit.stderr or terra_explicit.stdout)
         self.assertTrue(json.loads(terra_explicit.stdout)["route_eligible"])
 
-    def test_preflight_rejects_native_luna_and_sol_fast(self) -> None:
+        terra_fast = self.run_preflight(
+            "--surface",
+            "native_subagent",
+            "--model",
+            "gpt-5.6-terra",
+            "--thinking",
+            "low",
+            "--speed",
+            "fast",
+            "--explicit-user-request",
+            "--runtime-confirmed",
+            "--service-tier-confirmed",
+            "--host",
+            "test-host",
+            "--provider-status",
+            "allowed",
+            "--data-allowed",
+        )
+        self.assertEqual(terra_fast.returncode, 0, terra_fast.stdout)
+        self.assertEqual(
+            json.loads(terra_fast.stdout)["runtime_evidence"]["service_tier"],
+            "priority",
+        )
+
+    def test_preflight_keeps_luna_app_only_and_requires_explicit_sol_fast(self) -> None:
         native_luna = self.run_preflight(
             "--surface",
             "native_subagent",
@@ -463,7 +548,31 @@ class SkillContractTests(unittest.TestCase):
             "--data-allowed",
         )
         self.assertEqual(sol_fast.returncode, 2, sol_fast.stdout)
-        self.assertIn("Luna-only routing policy", sol_fast.stdout)
+        self.assertIn("requires an explicit user request", sol_fast.stdout)
+
+        sol_fast_explicit = self.run_preflight(
+            "--surface",
+            "native_subagent",
+            "--model",
+            "gpt-5.6-sol",
+            "--thinking",
+            "high",
+            "--speed",
+            "fast",
+            "--explicit-user-request",
+            "--runtime-confirmed",
+            "--service-tier-confirmed",
+            "--host",
+            "test-host",
+            "--provider-status",
+            "allowed",
+            "--data-allowed",
+        )
+        self.assertEqual(sol_fast_explicit.returncode, 0, sol_fast_explicit.stdout)
+        self.assertEqual(
+            json.loads(sol_fast_explicit.stdout)["runtime_evidence"]["service_tier"],
+            "priority",
+        )
 
     def test_preflight_emits_app_speed_evidence_only_when_live_schema_accepts_it(self) -> None:
         confirmed = self.run_preflight(
@@ -831,7 +940,7 @@ class SkillContractTests(unittest.TestCase):
         self.assertEqual(invalid.returncode, 2, invalid.stderr or invalid.stdout)
         self.assertIn("unsupported thinking", invalid.stdout)
 
-    def test_route_plan_validator_allows_fast_only_for_luna(self) -> None:
+    def test_route_plan_validator_defaults_fast_to_luna_and_allows_explicit_sol(self) -> None:
         plan = {
             "schema_version": "2.1",
             "task_class": "DEFAULT_GENERAL",
@@ -860,7 +969,15 @@ class SkillContractTests(unittest.TestCase):
         plan["candidates"][0]["speed_evidence"]["model"] = "gpt-5.6-sol"
         sol_fast = self.run_route_validator(plan)
         self.assertEqual(sol_fast.returncode, 2, sol_fast.stderr or sol_fast.stdout)
-        self.assertIn("Luna-only routing policy", sol_fast.stdout)
+        self.assertIn("non-default Fast requires explicit_user_request", sol_fast.stdout)
+
+        plan["explicit_user_request"] = True
+        sol_fast_explicit = self.run_route_validator(plan)
+        self.assertEqual(
+            sol_fast_explicit.returncode,
+            0,
+            sol_fast_explicit.stderr or sol_fast_explicit.stdout,
+        )
 
     def test_route_plan_validator_rejects_native_luna_even_with_runtime_evidence(self) -> None:
         plan = {
@@ -1218,9 +1335,11 @@ class SkillContractTests(unittest.TestCase):
         model: str,
         thinking: str,
         speed: str,
+        explicit_user_request: bool = False,
     ) -> dict[str, object]:
         return {
             "schema_version": "2.1",
+            "explicit_user_request": explicit_user_request,
             "candidates": [
                 {
                     "surface": surface,
@@ -1417,6 +1536,49 @@ class SkillContractTests(unittest.TestCase):
         result = self.run_ledger_validator([active])
         self.assertEqual(result.returncode, 0, result.stderr or result.stdout)
 
+    def test_ledger_validator_applies_expanded_team_plan_limits(self) -> None:
+        plan = self.team_plan(
+            unit_count=7,
+            scale_profile="expanded",
+            scale_reason="Seven isolated outputs can be reviewed independently.",
+        )
+        plan["reserved_slots"] = 2
+        workers = []
+        for index in range(1, 8):
+            workers.append(
+                self.ledger_record(
+                    creation_attempt=index,
+                    task_id=f"task-expanded-{index}",
+                    thread_id=None,
+                    pending_worktree_id=None,
+                    control_state="PLANNED",
+                    thread_status=None,
+                    turn_status=None,
+                    last_observed_at=None,
+                    materialized=False,
+                    data_ready=False,
+                    status="planned",
+                    output=None,
+                    adopted=False,
+                    archived=False,
+                    unit_id=f"U{index}",
+                    team_plan_revision=1,
+                )
+            )
+        result = self.run_ledger_validator(
+            {
+                "creation_attempts": 7,
+                "worker_attempts": 7,
+                "team_plans": [plan],
+                "active_team_plan_revision": 1,
+                "workers": workers,
+            }
+        )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["scale_profile"], "expanded")
+        self.assertEqual(payload["in_flight_count"], 7)
+
     def test_ledger_validator_rejects_inspect_source_mutation(self) -> None:
         inspect = self.ledger_record(
             task_intent="inspect",
@@ -1466,7 +1628,7 @@ class SkillContractTests(unittest.TestCase):
         self.assertEqual(invalid.returncode, 2, invalid.stdout)
         self.assertIn("missing speed audit fields", invalid.stdout)
 
-    def test_ledger_validator_preserves_luna_only_fast_identity(self) -> None:
+    def test_ledger_validator_distinguishes_default_and_explicit_fast(self) -> None:
         route_plan = self.route_plan_21(
             surface="app_thread",
             model="gpt-5.6-luna",
@@ -1498,7 +1660,17 @@ class SkillContractTests(unittest.TestCase):
         )
         invalid = self.run_ledger_validator([sol_fast])
         self.assertEqual(invalid.returncode, 2, invalid.stdout)
-        self.assertIn("Luna-only routing policy", invalid.stdout)
+        self.assertIn("non-default Fast lacks explicit_user_request", invalid.stdout)
+
+        sol_fast["route_plan"] = self.route_plan_21(
+            surface="app_thread",
+            model="gpt-5.6-sol",
+            thinking="xhigh",
+            speed="fast",
+            explicit_user_request=True,
+        )
+        explicit = self.run_ledger_validator([sol_fast])
+        self.assertEqual(explicit.returncode, 0, explicit.stdout)
 
     def test_ledger_validator_accepts_native_light_ledger_from_stdin(self) -> None:
         payload = [self.native_ledger_record(worker_attempt=1)]


### PR DESCRIPTION
## Summary

- separate Fast eligibility from default preference: Luna defaults to Fast, while Sol and Terra default to Standard and require explicit request plus live priority evidence for Fast
- add registry-backed TeamPlan profiles: standard 6/8/3 and justified expanded 12/16/6 with reserved recovery slots and narrower live-host limits taking precedence
- update validators, ledgers, schemas, docs, evals, and regression coverage

## Validation

- `python3 -m unittest tests.skills.test_codex_model_routing_team -v` — 58 passed
- `python3 -m unittest discover -s tests -v` — 93 passed
- Skill validator — clear, 0 blockers and 0 warnings
- strict Portfolio audit — clear, only 3 pre-existing binary asset warnings in unrelated Skills
- isolated copy install — passed, 29 files byte-for-byte identical
- `npx --no-install skills add . --list` — passed

## Policy boundary

The expanded profile is a policy ceiling, not a runtime guarantee. It requires an explicit scale reason, isolated ownership, at least two reserved slots, and compliance with any narrower live host limit.