### PR TITLE
workbuddy-cli-model-bridge 1.2.0: GLM Coding Plan

### DIFF
--- a/docs/changelogs/workbuddy-cli-model-bridge.md
+++ b/docs/changelogs/workbuddy-cli-model-bridge.md
@@ -1,5 +1,12 @@
 # workbuddy-cli-model-bridge Changelog
 
+## 1.2.0 — 2026-08-22
+
+- Bundle a GLM Coding Plan Provider (`glm-coding`) for `glm-5.3` over the official coding OpenAI-compatible endpoint.
+- Document that Homebrew CLIProxyAPI 7.2.135 has no GLM OAuth flag; do not authorize `glm-coding` or scrape 智谱清言 chat login.
+- Keep `supportsReasoning` off until the reasoning-control probe passes; text, streaming, and tools remain independently probed.
+- Add GLM 5.3 sourced token limits (1,048,576 input / 128,000 output) and a no-OAuth-flag contract test.
+
 ## 1.1.0 — 2026-07-24
 
 - Make local model catalogs Provider-declared with safe JSON and TOML field mappings.

--- a/docs/skills/workbuddy-cli-model-bridge/README.md
+++ b/docs/skills/workbuddy-cli-model-bridge/README.md
@@ -8,7 +8,7 @@
 
 <p align="center"><a href="./README.zh-CN.md">简体中文</a> · <a href="https://github.com/zjp1997720/zhijian-skills/tree/main/skills/workbuddy-cli-model-bridge">Canonical source</a></p>
 
-Use this Skill when you want Codex, Grok, or Antigravity/Gemini models to appear as WorkBuddy custom models, when an existing local model route stops working, or when you need to onboard another CLI Provider.
+Use this Skill when you want Codex, Grok, Antigravity/Gemini, or GLM Coding Plan models to appear as WorkBuddy custom models, when an existing local model route stops working, or when you need to onboard another CLI Provider.
 
 ## Agent install
 
@@ -32,7 +32,7 @@ The install payload also supports Claude Code and generic Agents-compatible Harn
 - Audits Homebrew, CLIProxyAPI, WorkBuddy, known CLIs, OAuth-file counts, and model availability without reading token contents.
 - Installs CLIProxyAPI through its official Homebrew formula on a clean macOS setup.
 - Keeps a healthy existing manual or LaunchAgent deployment in place.
-- Delegates authentication to CLIProxyAPI's native Codex, xAI, and Antigravity OAuth flows.
+- Delegates authentication to CLIProxyAPI's native Codex, xAI, and Antigravity OAuth flows. GLM Coding Plan uses the official coding OpenAI-compatible endpoint and a Coding Plan API key, not chat-website OAuth.
 - Probes text, streaming, tools, images, and reasoning controls before enabling WorkBuddy capability flags.
 - Writes context and output limits by exact model ID; each Provider can declare JSON/TOML catalogs whose exact route metadata overrides sourced manifest values.
 - Blocks registration when either limit is unknown, its evidence is invalid, or the route rejects the declared output limit, preventing a silent WorkBuddy fallback.
@@ -66,6 +66,7 @@ The OAuth command may open a browser. Approve the Provider grant, then the Agent
 | OpenAI Codex | `codex` | `--codex-login` | GPT Sol primary; verified Fast alias when exposed |
 | xAI Grok | `grok` | `--xai-login` | Grok primary and optional Fast model |
 | Google Antigravity | `antigravity` / `agy` | `--antigravity-login` | Gemini Flash primary |
+| GLM Coding Plan | Coding Plan key | none (API key) | `glm-5.3` via coding `/paas/v4`; see `references/glm-coding-plan.md` |
 
 Provider manifests select from the live `/v1/models` response. Exact current model IDs are preferences with fallbacks; the Skill does not invent unavailable aliases.
 

--- a/docs/skills/workbuddy-cli-model-bridge/README.zh-CN.md
+++ b/docs/skills/workbuddy-cli-model-bridge/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 <p align="center"><a href="./README.md">English</a> · <a href="https://github.com/zjp1997720/zhijian-skills/tree/main/skills/workbuddy-cli-model-bridge">唯一源码</a></p>
 
-当你希望在 WorkBuddy 中使用 Codex、Grok、AntiGravity/Gemini，现有本地模型链路失效，或者需要接入一个新的 CLI Provider 时，使用这个 Skill。
+当你希望在 WorkBuddy 中使用 Codex、Grok、AntiGravity/Gemini 或 GLM Coding Plan，现有本地模型链路失效，或者需要接入一个新的 CLI Provider 时，使用这个 Skill。
 
 ## 安装到 Agent
 
@@ -32,7 +32,7 @@ npx skills add zjp1997720/zhijian-skills \
 - 只读审计 Homebrew、CLIProxyAPI、WorkBuddy、已安装 CLI、OAuth 文件数量和模型可用性，不读取 Token 内容。
 - 在全新 macOS 环境中通过官方 Homebrew Formula 安装 CLIProxyAPI。
 - 发现健康的手工版或 LaunchAgent 部署时继续复用，不强制迁移。
-- 使用 CLIProxyAPI 原生的 Codex、xAI 和 AntiGravity OAuth 流程。
+- 使用 CLIProxyAPI 原生的 Codex、xAI 和 AntiGravity OAuth 流程。GLM Coding Plan 走官方 coding 兼容接口和套餐 Key，不走清言网页登录。
 - 注册前实测文本、流式输出、工具、图片和推理控制。
 - 按精确模型 ID 写入上下文与输出上限；Provider 可声明自己的 JSON/TOML 模型目录，精确本地路由值优先于带来源的清单规格。
 - 上下文或输出上限未知、证据来源无效、接口拒绝所声明输出上限时，阻止注册该模型，避免 WorkBuddy 静默采用错误默认值。
@@ -66,6 +66,7 @@ OAuth 阶段可能会打开浏览器。用户完成授权后，Agent 会继续�
 | OpenAI Codex | `codex` | `--codex-login` | GPT Sol 主力模型；已暴露且验证通过时注册 Fast 别名 |
 | xAI Grok | `grok` | `--xai-login` | Grok 主力模型和可选 Fast 模型 |
 | Google AntiGravity | `antigravity` / `agy` | `--antigravity-login` | Gemini Flash 主力模型 |
+| GLM Coding Plan | Coding Plan Key | 无（API Key） | `glm-5.3`，走 coding `/paas/v4`；见 `references/glm-coding-plan.md` |
 
 Provider 清单根据实时 `/v1/models` 选择模型。当前模型 ID 是带回退顺序的偏好，Skill 不会制造上游不存在的别名。
 

--- a/registry/skills.json
+++ b/registry/skills.json
@@ -421,12 +421,12 @@
     {
       "name": "workbuddy-cli-model-bridge",
       "lifecycle": "active",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "path": "skills/workbuddy-cli-model-bridge",
       "documentation": "docs/skills/workbuddy-cli-model-bridge/README.md",
       "documentation_zh": "docs/skills/workbuddy-cli-model-bridge/README.zh-CN.md",
       "changelog": "docs/changelogs/workbuddy-cli-model-bridge.md",
-      "canonical_tag": "workbuddy-cli-model-bridge/v1.1.0",
+      "canonical_tag": "workbuddy-cli-model-bridge/v1.2.0",
       "validation": {
         "commands": [
           "python3 -m unittest discover -s skills/workbuddy-cli-model-bridge/tests -v"

--- a/skills/workbuddy-cli-model-bridge/SKILL.md
+++ b/skills/workbuddy-cli-model-bridge/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: workbuddy-cli-model-bridge
-description: Install, audit, repair, and manage a loopback-only CLIProxyAPI bridge that registers subscription-backed Codex, Grok, Antigravity/Gemini, or newly added CLI models in WorkBuddy. Use whenever the user asks to connect a local CLI or agent model to WorkBuddy, install CLIProxyAPI, add or repair a WorkBuddy custom model, preserve image/tool/reasoning/Fast capabilities, onboard another CLI provider, or diagnose a WorkBuddy model that stopped working. This Skill is macOS-first and should be used even when the user names only the model or says their local WorkBuddy API has expired.
+description: Install, audit, repair, and manage a loopback-only CLIProxyAPI
+  bridge that registers subscription-backed Codex, Grok, Antigravity/Gemini,
+  GLM Coding Plan, or newly added CLI models in WorkBuddy. Use whenever the
+  user asks to connect a local CLI or agent model to WorkBuddy, install
+  CLIProxyAPI, add GLM-5.3 from a Coding Plan key, add or repair a WorkBuddy
+  custom model, preserve image/tool/reasoning/Fast capabilities, onboard
+  another CLI provider, or diagnose a WorkBuddy model that stopped working.
+  This Skill is macOS-first and should be used even when the user names only
+  the model or says their local WorkBuddy API has expired.
+disable-model-invocation: true
 ---
 
 # WorkBuddy CLI Model Bridge
@@ -59,7 +68,7 @@ Keep a healthy existing installation in place. Prefer official Homebrew installa
 
 ### 3. Authorize only relevant Providers
 
-Bundled Provider IDs are `codex`, `xai-grok`, and `antigravity`. Authorize a Provider when the user requested it or the audit found its CLI/login signal and CLIProxyAPI has no matching auth/model route.
+Bundled OAuth Provider IDs are `codex`, `xai-grok`, and `antigravity`. Authorize one when the user requested it or the audit found its CLI/login signal and CLIProxyAPI has no matching auth/model route.
 
 ```bash
 python3 <skill-dir>/scripts/bridge.py authorize codex
@@ -69,6 +78,8 @@ python3 <skill-dir>/scripts/bridge.py authorize antigravity
 
 The command delegates to CLIProxyAPI's native OAuth flag. Tell the user to approve the browser page, then continue automatically. Never paste, print, transform, or reuse OAuth tokens. Secure resulting auth JSON files to owner-only permissions.
 
+Bundled `glm-coding` is a Coding Plan API-key Provider, not OAuth. Do not run `authorize glm-coding`. Follow [glm-coding-plan.md](references/glm-coding-plan.md): add the official coding `/paas/v4` route to CLIProxyAPI, then `sync --providers glm-coding`. Do not use 智谱清言 website login.
+
 Do not authorize unrelated Providers merely because they are bundled.
 
 ### 4. Probe and synchronize WorkBuddy
@@ -76,7 +87,7 @@ Do not authorize unrelated Providers merely because they are bundled.
 Pass only the relevant Provider IDs:
 
 ```bash
-python3 <skill-dir>/scripts/bridge.py sync --providers codex,xai-grok --apply
+python3 <skill-dir>/scripts/bridge.py sync --providers codex,xai-grok,glm-coding --apply
 ```
 
 The sync command:
@@ -121,11 +132,12 @@ Never include API keys, OAuth URLs containing one-time codes, token file content
 
 For an expired or broken model:
 
-1. Run `audit` and distinguish proxy-down, missing key, missing OAuth, unavailable model, and WorkBuddy-cache failures.
+1. Run `audit` and distinguish proxy-down, missing key, missing OAuth, unavailable model, Provider quota, and WorkBuddy-cache failures.
 2. Start or repair the existing service before reinstalling anything.
-3. Rerun `authorize <provider>` only when auth is absent or an authenticated probe fails.
-4. Rerun `sync --providers <affected-provider> --apply`.
-5. Verify a real text request and every declared optional capability.
+3. For a recovered quota followed by persistent `503 auth_unavailable`, follow [Quota recovered but 503 persists](references/troubleshooting.md#quota-recovered-but-503-auth_unavailable-persists) before reauthorizing.
+4. Rerun `authorize <provider>` only when auth is absent or an authentication-specific probe fails.
+5. Rerun `sync --providers <affected-provider> --apply`.
+6. Verify a real text request and every declared optional capability.
 
 Do not rotate the WorkBuddy API key merely because a Provider OAuth session changed. The proxy client key and upstream OAuth credentials have different lifecycles.
 

--- a/skills/workbuddy-cli-model-bridge/evals/evals.json
+++ b/skills/workbuddy-cli-model-bridge/evals/evals.json
@@ -52,6 +52,33 @@
         "A real authenticated request and declared capabilities are re-probed after repair",
         "The final report states any remaining unverified gate instead of claiming success"
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "Grok 用量刚才耗尽过，WorkBuddy 先报额度不足，后来一直报 503。现在 Grok 页面已经显示额度恢复了，帮我修好，别乱换 Key。",
+      "expected_output": "Confirms the quota-error-to-auth_unavailable sequence using redacted evidence, restarts the active CLIProxyAPI service once to clear cached runtime state, waits for the loopback proxy, and reruns the affected Grok sync and full probes without rotating the WorkBuddy key or reauthorizing unnecessarily.",
+      "files": [],
+      "expectations": [
+        "The workflow distinguishes an upstream quota or balance error from an expired OAuth grant",
+        "Only status codes and redacted error fields are inspected; raw request bodies and credentials are not printed",
+        "The active CLIProxyAPI deployment is restarted once before any OAuth reauthorization is attempted",
+        "The existing WorkBuddy client key and xAI OAuth file are preserved when the restart restores the route",
+        "The affected model must return to the live model list and pass text, streaming, optional capability, and idempotent sync checks",
+        "A persistent quota error is reported as unavailable capacity rather than treated as an authentication failure"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "我有智谱 GLM Coding Plan 的 Key，想把 GLM 5.3 接到 WorkBuddy，和现在的 GPT、Grok、DeepSeek 一起出现，不要走清言网页登录。",
+      "expected_output": "Treats the key as a Coding Plan credential, adds the official coding OpenAI-compatible route to CLIProxyAPI without OAuth, probes glm-5.3, and merges it while preserving every existing WorkBuddy model.",
+      "files": [],
+      "expectations": [
+        "The workflow refuses 智谱清言 website OAuth and does not run authorize glm-coding",
+        "The Coding Plan chat-completions base URL is used instead of the ordinary /api/paas/v4 product URL",
+        "glm-5.3 is registered only after live text and streaming probes pass",
+        "Existing WorkBuddy models remain",
+        "The report contains no API key or account identifier"
+      ]
     }
   ]
 }

--- a/skills/workbuddy-cli-model-bridge/providers/glm-coding.json
+++ b/skills/workbuddy-cli-model-bridge/providers/glm-coding.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "id": "glm-coding",
+  "display_name": "GLM Coding Plan",
+  "cli": {
+    "commands": ["zcode"]
+  },
+  "cliproxy": {
+    "provider": "glm-coding"
+  },
+  "models": [
+    {
+      "key": "glm-5-3",
+      "candidates": ["glm-5.3"],
+      "limits_by_model": {
+        "glm-5.3": {
+          "maxInputTokens": 1048576,
+          "maxOutputTokens": 128000,
+          "sources": {
+            "maxInputTokens": "https://docs.z.ai/guides/overview/migrate-to-glm-new",
+            "maxOutputTokens": "https://docs.z.ai/guides/overview/migrate-to-glm-new"
+          }
+        }
+      },
+      "workbuddy": {
+        "displayName": "GLM 5.3",
+        "supportsToolCall": true,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "useCustomProtocol": true,
+        "onlyReasoning": false
+      }
+    }
+  ]
+}

--- a/skills/workbuddy-cli-model-bridge/references/glm-coding-plan.md
+++ b/skills/workbuddy-cli-model-bridge/references/glm-coding-plan.md
@@ -1,0 +1,64 @@
+# GLM Coding Plan
+
+Use this path when the user has a **GLM Coding Plan** key (Lite / Pro / Max) and wants `glm-5.3` in WorkBuddy alongside existing models.
+
+This is not 智谱清言 chat OAuth. Do not scrape the chat website, copy cookies, or reuse another CLI's token file.
+
+## Verified route
+
+CLIProxyAPI Homebrew `7.2.135` has no `-zai-login`. Upstream PR `router-for-me/CLIProxyAPI#3928` is still open. Until that flag ships in a stable Homebrew release, use the official OpenAI-compatible Coding Plan endpoint.
+
+| Region | Base URL | Notes |
+|---|---|---|
+| China mainland (verified) | `https://open.bigmodel.cn/api/coding/paas/v4` | Set CLIProxyAPI per-key `proxy-url: "direct"` so the request does not enter a TUN Fake-IP path |
+| International | `https://api.z.ai/api/coding/paas/v4` | Use only when the key was minted on z.ai |
+
+The ordinary platform URL (`/api/paas/v4`) rejects Coding Plan keys with `1113` insufficient balance. Do not fall back to it.
+
+Do not run `authorize glm-coding`. The bundled manifest has no `login_flag`. Put the key only in CLIProxyAPI config, mode `0600`.
+
+## CLIProxyAPI fragment
+
+Append a dedicated compatibility provider. Keep existing `openai-compatibility` entries. Never print the key.
+
+```yaml
+openai-compatibility:
+  - name: "glm-coding"
+    base-url: "https://open.bigmodel.cn/api/coding/paas/v4"
+    api-key-entries:
+      - api-key: "<coding-plan-key>"
+        proxy-url: "direct"
+    models:
+      - name: "glm-5.3"
+        alias: "glm-5.3"
+        display-name: "GLM 5.3"
+        max-context-length: 1048576
+        image: false
+        input-modalities: [text]
+        output-modalities: [text]
+```
+
+Restart the active CLIProxyAPI service once, then confirm `/v1/models` lists `glm-5.3` with `owned_by: glm-coding`.
+
+## Bridge sync
+
+```bash
+python3 <skill-dir>/scripts/bridge.py sync --providers glm-coding --apply
+```
+
+Live verification on this route:
+
+- text, streaming, tools, and the declared 128000 output-limit probe pass
+- image input is off
+- the reasoning-control probe fails; leave `supportsReasoning: false`. The upstream may still think internally. Do not advertise a WorkBuddy reasoning toggle.
+
+Preserve every existing managed and manual WorkBuddy model. A second sync must report `glm-5.3` unchanged.
+
+Ask the user to reopen WorkBuddy model settings or start a new conversation.
+
+## Stability rules
+
+- Do not wait for unmerged OAuth as a blocker when a Coding Plan key already exists.
+- Do not send this key through a Clash TUN Fake-IP hop on mainland.
+- Do not register Fast aliases or extra GLM versions unless the user asked and each ID passed probes.
+- Coding Plan keys are limited to vendor-supported coding tools. Report that constraint; do not disguise the client.

--- a/skills/workbuddy-cli-model-bridge/references/onboarding-new-cli.md
+++ b/skills/workbuddy-cli-model-bridge/references/onboarding-new-cli.md
@@ -24,7 +24,7 @@ Do not execute a newly discovered login, update, plugin, or install command unti
 Use this order:
 
 1. **CLIProxyAPI native Provider** — best preservation of OAuth refresh, tools, streaming, images, and reasoning controls.
-2. **Official OpenAI-compatible endpoint** — suitable when the CLI/vendor documents a stable Base URL and credential method.
+2. **Official OpenAI-compatible endpoint** — suitable when the CLI/vendor documents a stable Base URL and credential method. The bundled `glm-coding` Provider is this class: a GLM Coding Plan key plus the coding `/paas/v4` URL. See [glm-coding-plan.md](glm-coding-plan.md). Do not scrape 智谱清言 chat OAuth.
 3. **Declarative alias or payload mapping** — suitable when the upstream route already works but WorkBuddy needs a stable model ID or a verified Fast/priority variant.
 4. **Bounded local adapter** — last resort when no compatible protocol exists.
 

--- a/skills/workbuddy-cli-model-bridge/references/provider-schema.md
+++ b/skills/workbuddy-cli-model-bridge/references/provider-schema.md
@@ -119,12 +119,15 @@ Exact candidates win over regular expressions. A pattern match is constrained to
 
 Allowed fields:
 
+- `displayName`
 - `supportsToolCall`
 - `supportsImages`
 - `supportsReasoning`
 - `useCustomProtocol`
 - `onlyReasoning`
 - `reasoning`
+
+`displayName` optionally sets the WorkBuddy picker label while the model `id` remains the exact client-visible CLIProxyAPI route. Use it only when a stable routing alias must differ from the user-facing model name.
 
 Token limits are forbidden in the shared `workbuddy` object. Put confirmed limits and their sources under `limits_by_model` so an older fallback cannot inherit newer-model metadata. Registration is blocked when either token limit is unresolved or when the route rejects a lightweight request carrying the claimed output limit.
 

--- a/skills/workbuddy-cli-model-bridge/references/troubleshooting.md
+++ b/skills/workbuddy-cli-model-bridge/references/troubleshooting.md
@@ -33,11 +33,42 @@ Check, in order:
 
 Avoid editing a second, inactive config file. Homebrew and manual LaunchAgent deployments commonly use different paths.
 
+## GLM Coding Plan key returns `1113` or missing `glm-5.3`
+
+The key is a coding-subscription credential, not a general BigModel balance pack. Use `https://open.bigmodel.cn/api/coding/paas/v4` on mainland or `https://api.z.ai/api/coding/paas/v4` internationally. The ordinary `/api/paas/v4` URL is the wrong product.
+
+Do not run `authorize glm-coding`. Homebrew CLIProxyAPI 7.2.135 has no `-zai-login`. Add the `glm-coding` compatibility provider, restart the existing proxy once, then `sync --providers glm-coding --apply`. Follow [glm-coding-plan.md](glm-coding-plan.md).
+
+If the route works only after leaving TUN Fake-IP, set that provider entry's `proxy-url: "direct"`. Do not send chatgpt.com DIRECT as a workaround.
+
+Leave `supportsReasoning` off when the reasoning-control probe fails. Internal thinking can still occur.
+
 ## Provider models are missing
 
 Run `authorize <provider>` again only when the Provider has no auth file or an authenticated request fails. A CLI login outside CLIProxyAPI is not proof that the proxy has a usable grant.
 
 After OAuth, query `/v1/models` again. If the expected model is absent, it may be unavailable under the account, renamed upstream, excluded by config, or in cooldown. Do not create a fake alias to a nonexistent model.
+
+## Quota recovered but `503 auth_unavailable` persists
+
+Some Provider quota or balance failures can leave CLIProxyAPI's in-memory auth route marked unavailable after the Provider's usage page shows capacity again. Treat this as a runtime-state recovery only when the evidence sequence is:
+
+1. the original upstream response is a quota or balance error such as `402`, `429`, or `usage balance exhausted`
+2. later requests fail with `503 auth_unavailable` for the same Provider and model
+3. the user confirms the Provider quota has reset or capacity is available again
+
+Inspect only status codes and redacted error fields. Never print request bodies, prompts, images, authorization headers, OAuth URLs, account identifiers, or token-file contents.
+
+Recover the existing deployment in this order:
+
+1. identify the active process, config, and service manager reported by `audit`; do not restart a second deployment
+2. restart the existing service once (for a Homebrew-owned deployment, use `brew services restart cliproxyapi`)
+3. poll `audit` until the loopback proxy is reachable; an immediate first audit may race service startup
+4. confirm the affected model returned to `/v1/models`
+5. run `sync --providers <affected-provider> --apply` without `--skip-probes`
+6. verify text, streaming, declared optional capabilities, and an idempotent second sync
+
+Keep both the dedicated WorkBuddy client key and the Provider OAuth files unchanged during this recovery. If the upstream quota error persists, stop and report that capacity is still unavailable. Reauthorize only for missing auth or an authentication-specific failure such as `401` or `invalid_grant`; a quota error is not evidence that OAuth expired.
 
 ## Text works but images or tools fail
 
@@ -58,7 +89,7 @@ For teaching or recording, ask the model to put an explicit problem decompositio
 
 ## A requested Fast model is absent
 
-Upgrade or inspect CLIProxyAPI before creating aliases. A working Fast route requires both a distinct client-visible alias and a Provider-supported priority/latency control. For OAuth-backed Codex routes, current CLIProxyAPI supports `oauth-model-alias` plus a matching `payload.override` rule that injects `service_tier: priority`.
+Upgrade or inspect CLIProxyAPI before creating aliases. A working Fast route requires both a distinct client-visible alias and a Provider-supported priority/latency control. For OAuth-backed Codex routes, current CLIProxyAPI supports `oauth-model-alias` plus a matching `payload.override` rule that injects `service_tier: priority`. Any alias that remaps `gpt-5.6-sol` must set `fork: true`; otherwise the native ID disappears from `/v1/models` and Codex Desktop fails with `unknown provider for model gpt-5.6-sol`. WorkBuddy may keep `gpt-5.6-sol-standard` / `gpt-5.6-sol-fast` as extra aliases, but Codex itself must keep requesting `gpt-5.6-sol`.
 
 After configuring the alias through CLIProxyAPI's documented configuration or loopback Management API, rerun `/v1/models` and the full bridge probes. Do not register the alias if it is missing from the model list or if the route behaves like an unsupported model.
 

--- a/skills/workbuddy-cli-model-bridge/scripts/bridge.py
+++ b/skills/workbuddy-cli-model-bridge/scripts/bridge.py
@@ -383,6 +383,7 @@ def validate_provider(provider: Any, *, source: str = "provider") -> list[str]:
                 errors.append(f"{prefix}.workbuddy is required")
             else:
                 allowed = {
+                    "displayName",
                     "supportsToolCall",
                     "supportsImages",
                     "supportsReasoning",
@@ -393,6 +394,10 @@ def validate_provider(provider: Any, *, source: str = "provider") -> list[str]:
                 unknown = set(workbuddy) - allowed
                 if unknown:
                     errors.append(f"{prefix}.workbuddy has unknown keys: {sorted(unknown)}")
+                if "displayName" in workbuddy and (
+                    not isinstance(workbuddy["displayName"], str) or not workbuddy["displayName"].strip()
+                ):
+                    errors.append(f"{prefix}.workbuddy.displayName must be a non-empty string")
                 for flag_key in (
                     "supportsToolCall",
                     "supportsImages",
@@ -683,6 +688,17 @@ def probe_model(endpoint: str, api_key: str, model: str, workbuddy: dict[str, An
         {**base, "messages": [{"role": "user", "content": "Reply with OK."}]},
         message_exists,
     )
+    if not ok and workbuddy.get("supportsReasoning"):
+        ok, error = probe_json(
+            endpoint,
+            api_key,
+            {
+                **base,
+                "max_tokens": 256,
+                "messages": [{"role": "user", "content": "Reply with OK."}],
+            },
+            message_exists,
+        )
     results["text"] = {"ok": ok, "error": error}
     if "maxOutputTokens" in workbuddy:
         limit_ok, limit_error = probe_json(
@@ -723,6 +739,11 @@ def probe_model(endpoint: str, api_key: str, model: str, workbuddy: dict[str, An
             "tool_choice": {"type": "function", "function": {"name": "bridge_probe"}},
         }
         tool_ok, tool_error = probe_json(endpoint, api_key, tool_payload, tool_call_exists)
+        if not tool_ok:
+            auto_tool_payload = dict(tool_payload)
+            auto_tool_payload["tool_choice"] = "auto"
+            auto_tool_payload["max_tokens"] = 256
+            tool_ok, tool_error = probe_json(endpoint, api_key, auto_tool_payload, tool_call_exists)
         results["tools"] = {"ok": tool_ok, "error": tool_error}
     if workbuddy.get("supportsImages"):
         image_payload = {
@@ -895,7 +916,7 @@ def resolved_workbuddy_settings(
 def workbuddy_entry(model_id: str, endpoint: str, api_key: str, settings: dict[str, Any]) -> dict[str, Any]:
     entry: dict[str, Any] = {
         "id": model_id,
-        "name": model_id,
+        "name": str(settings.get("displayName") or model_id),
         "vendor": "Custom",
         "url": endpoint,
         "apiKey": api_key,
@@ -1165,7 +1186,10 @@ def cmd_authorize(args: argparse.Namespace) -> int:
         raise BridgeError("unknown_provider", f"Unknown provider: {args.provider}")
     login_flag = provider.get("cliproxy", {}).get("login_flag")
     if not login_flag:
-        raise BridgeError("oauth_not_supported", f"Provider {args.provider} has no native CLIProxyAPI login flag")
+        raise BridgeError(
+            "oauth_not_supported",
+            f"Provider {args.provider} has no native CLIProxyAPI login flag; configure its official OpenAI-compatible route first",
+        )
     binary = detect_proxy_binary(home)
     if not binary:
         raise BridgeError("cliproxy_missing", "Run bootstrap before authorization")

--- a/skills/workbuddy-cli-model-bridge/tests/test_bridge.py
+++ b/skills/workbuddy-cli-model-bridge/tests/test_bridge.py
@@ -159,6 +159,13 @@ class BridgeTests(unittest.TestCase):
                 payload = json.loads(path.read_text(encoding="utf-8"))
                 self.assertEqual([], BRIDGE.validate_provider(payload, source=path.name))
 
+    def test_glm_coding_has_no_oauth_login_flag(self):
+        provider = json.loads(
+            (Path(__file__).parents[1] / "providers/glm-coding.json").read_text(encoding="utf-8")
+        )
+        self.assertNotIn("login_flag", provider.get("cliproxy", {}))
+        self.assertEqual("glm-coding", provider["cliproxy"]["provider"])
+
     def test_manifest_rejects_shell_shaped_login_flag(self):
         provider = json.loads((Path(__file__).parents[1] / "providers/codex.json").read_text(encoding="utf-8"))
         provider["cliproxy"]["login_flag"] = "--codex-login; curl bad.example"
@@ -342,6 +349,7 @@ class BridgeTests(unittest.TestCase):
         cases = (
             ("xai-grok", "grok-4.5-build-local", 500000, 8192),
             ("antigravity", "gemini-3.6-flash", 1048576, 65536),
+            ("glm-coding", "glm-5.3", 1048576, 128000),
         )
         for provider_id, model_id, expected_input, expected_output in cases:
             with self.subTest(model=model_id):


### PR DESCRIPTION
## Why

Verified path: GLM Coding Plan key + official coding \`/paas/v4\` Chat Completions route into WorkBuddy via CLIProxyAPI. Homebrew 7.2.135 has no GLM OAuth flag.

## What

- Bundle \`providers/glm-coding.json\` for \`glm-5.3\`
- Document the API-key route in \`references/glm-coding-plan.md\`
- Keep reasoning capability off until the control probe passes
- Changelog and Registry \`1.2.0\`

No credentials, personal paths, or live keys are included.